### PR TITLE
Doc:  typing and internal docstrings

### DIFF
--- a/.github/workflows/test-posix.yml
+++ b/.github/workflows/test-posix.yml
@@ -17,6 +17,7 @@ jobs:
       max-parallel: 5
       matrix:
         os: [ubuntu-latest, macos-latest]
+        python-version: ['3.10']
         include:
           - os: ubuntu-latest
             cv: 1
@@ -30,6 +31,7 @@ jobs:
       with:
         auto-update-conda: true
         miniforge-version: latest
+        python-version: ${{ matrix.python-version }}
         environment-file: env-dev.yml
         activate-environment: ncrf
         auto-activate-base: false

--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,8 @@ ncrf/dsyevh3C/__pycache__/
 ncrf/opt.c
 ncrf/dsyevh3C/*.pxd
 ncrf/dsyevh3C/*.cpp
+ncrf/dsyevh3C/dsyevh3py.c
+ncrf-testing-data
 *.html
 ncrf_data
 .pytest_cache

--- a/README.md
+++ b/README.md
@@ -3,14 +3,14 @@
 
 ![test-windows](https://github.com/proloyd/neuro-currentRF/actions/workflows/test-windows.yml/badge.svg)
 
-# Wanna try ncRFs for your data???
-
-Tutorial on real dataset is now available [here](https://github.com/proloyd/neuro-currentRF/wiki/NCRF-tutorial).
 
 # NCRF   
 The magnetoencephalography (MEG) response to continuous auditory stimuli, such as speech, is commonly described using a linear filter, the auditory temporal response function (TRF). Though components of the sensor level TRFs have been well characterized, the cortical distributions of  the underlying neural responses are not well-understood. In our recent work, we provide a unified framework for determining the TRFs of neural sources directly from the MEG data, by integrating the TRF and distributed forward  source models into one, and casting the joint estimation task as a Bayesian optimization problem. Though the resulting  problem emerges as non-convex, we propose efficient solutions that leverage recent advances in evidence maximization. For more details please refer to [1], [2].
 
-This repository contains the implementation of our direct TRF estimation algorithm in python (version 3.6 and above). 
+This repository contains the implementation of our direct TRF estimation algorithm in Python.
+
+For code examples using real datasets, see the [Example gallery](https://eelbrain.github.io/neuro-currentRF/auto_examples/index.html).
+
 
 ## How to use:
 run

--- a/docs/api/index.rst
+++ b/docs/api/index.rst
@@ -9,3 +9,5 @@ The ``ncrf`` module provide functions for fitting NCRFs from data.
     :toctree: generated/
 
     fit_ncrf
+    NCRF
+    RegressionData

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -30,16 +30,13 @@ extensions = [
     "sphinx.ext.intersphinx",
     "sphinx.ext.autosummary",
     "sphinx.ext.mathjax",
+    "sphinx.ext.napoleon",
     'sphinx_gallery.gen_gallery',
     "sphinxcontrib.bibtex",
-    "numpydoc",
     "sphinx.ext.githubpages",  # .nojekyll file on generated HTML directory to publish the document on GitHub Pages. 
 ]
 
-templates_path = ['_templates']
-exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
-
-templates_path = ["_templates"]
+templates_path = ["templates"]
 exclude_patterns = ["_build", "Thumbs.db", ".DS_Store", "**.ipynb_checkpoints"]
 
 # Sphinx will warn about all references where the target cannot be found.
@@ -48,11 +45,6 @@ nitpick_ignore = [("py:obj", "optional"), ("py:obj", "NCRF")]
 
 # A list of ignored prefixes for module index sorting.
 modindex_common_prefix = [f"{package}."]
-
-# The name of a reST role (builtin or Sphinx extension) to use as the default role, that
-# is, for text marked up `like this`. This can be set to 'py:obj' to make `filter` a
-# cross-reference to the Python function “filter”.
-default_role = "autolink"
 
 # list of warning types to suppress
 suppress_warnings = [
@@ -79,6 +71,21 @@ autodoc_member_order = "groupwise"
 autodoc_warningiserror = True
 autoclass_content = "class"
 
+# -- napoleon --------------------------------------------------------------------------
+napoleon_google_docstring = False
+napoleon_include_init_with_doc = True
+napoleon_include_special_with_doc = False
+napoleon_use_param = True
+napoleon_use_ivar = True
+napoleon_use_keyword = True
+napoleon_use_rtype = True
+
+qualname_overrides = {
+    "ncrf._model.NCRF": "ncrf.NCRF",
+    "ncrf._model.RegressionData": "ncrf.RegressionData",
+    "ncrf._ncrf.fit_ncrf": "ncrf.fit_ncrf",
+}
+
 # -- intersphinx -----------------------------------------------------------------------
 intersphinx_mapping = get_intersphinx_mapping(
     packages={
@@ -97,30 +104,6 @@ intersphinx_mapping.update({
     'surfer': ('https://pysurfer.github.io', None),
 })
 intersphinx_timeout = 5
-
-# x-ref
-numpydoc_xref_param_type = True
-numpydoc_xref_aliases = {
-    # Matplotlib
-    "Axes": "matplotlib.axes.Axes",
-    "Figure": "matplotlib.figure.Figure",
-    # MNE
-    "DigMontage": "mne.channels.DigMontage",
-    "Epochs": "mne.Epochs",
-    "Evoked": "mne.Evoked",
-    "Info": "mne.Info",
-    "Projection": "mne.Projection",
-    "Raw": "mne.io.Raw",
-    # Python
-    "bool": ":class:`python:bool`",
-    "Path": "pathlib.Path",
-    "TextIO": "io.TextIOBase",
-    # Eelbrain
-    "NDVar": "eelbrain.NDVar",
-    "case": "eelbrain.Case",
-    "sensor": "eelbrain.Sensor",
-    "time": "eelbrain.UTS"
-}
 
 # -- sphinx-gallery
 

--- a/docs/templates/autosummary/class.rst
+++ b/docs/templates/autosummary/class.rst
@@ -1,0 +1,22 @@
+{{ fullname | escape | underline }}
+
+.. currentmodule:: {{ module }}
+
+.. autoclass:: {{ objname }}
+
+
+{% block methods %}
+{% if methods %}
+
+.. rubric:: Methods
+
+.. autosummary::
+   :toctree: generated
+
+{% for item in methods %}
+   {%- if not item.startswith('_') or item in ['__call__'] %}
+   ~{{ name }}.{{ item }}
+   {%- endif -%}
+{%- endfor %}
+{% endif %}
+{% endblock %}

--- a/docs/templates/autosummary/module.rst
+++ b/docs/templates/autosummary/module.rst
@@ -1,0 +1,3 @@
+{{ fullname | escape | underline }}
+
+.. automodule:: {{ fullname }}

--- a/docs/templates/class_nomethods.rst
+++ b/docs/templates/class_nomethods.rst
@@ -1,0 +1,5 @@
+{{ fullname | escape | underline }}
+
+.. currentmodule:: {{ module }}
+
+.. autoclass:: {{ objname }}

--- a/ncrf/__init__.py
+++ b/ncrf/__init__.py
@@ -5,5 +5,5 @@ coordinates input normalization and model fitting, while :class:`NCRF` and
 :class:`RegressionData` expose the lower-level object-oriented workflow.
 """
 
-from ._model import NCRF, RegressionData, gaussian_basis
+from ._model import NCRF, RegressionData
 from ._ncrf import fit_ncrf

--- a/ncrf/__init__.py
+++ b/ncrf/__init__.py
@@ -1,2 +1,9 @@
-from ._ncrf import fit_ncrf
+"""Public package surface for the NCRF fitting pipeline.
+
+The package is organized around a small top-level API: :func:`fit_ncrf`
+coordinates input normalization and model fitting, while :class:`NCRF` and
+:class:`RegressionData` expose the lower-level object-oriented workflow.
+"""
+
 from ._model import NCRF, RegressionData, gaussian_basis
+from ._ncrf import fit_ncrf

--- a/ncrf/_crossvalidation.py
+++ b/ncrf/_crossvalidation.py
@@ -1,19 +1,30 @@
+"""Cross-validation helpers used by the NCRF estimator.
+
+The core model owns fitting and scoring logic, while this module supplies the
+execution machinery for sweeping regularization values and splitting time-series
+data into train/test windows.
+"""
+
+from __future__ import annotations
+
 # Author: Proloy Das <email:proloyd94@gmail.com>
 # License: BSD (3-clause)
-from __future__ import annotations
 
 import os
 from math import ceil
 from multiprocessing import Process, Queue
 import queue
-from typing import TYPE_CHECKING, List, Sequence
+from typing import TYPE_CHECKING, Callable, Iterator, List, Sequence
 
 from eelbrain._config import CONFIG
 import numpy as np
+import numpy.typing as npt
 from tqdm import tqdm
 
 if TYPE_CHECKING:
     from ._model import NCRF, RegressionData
+
+FloatArray = npt.NDArray[np.float64]
 
 
 class CVResult:
@@ -47,8 +58,15 @@ class CVResult:
         self.l2_error = l2_error
 
 
-def naive_worker(fun, data, n_split, tol, job_q, result_q):
-    """Worker function"""
+def naive_worker(
+        fun: Callable[[RegressionData, int, float, float], CVResult],
+        data: RegressionData,
+        n_split: int,
+        tol: float,
+        job_q: Queue,
+        result_q: Queue,
+) -> None:
+    """Consume regularization values from the shared queue and score them."""
     # myname = current_process().name
     if CONFIG['nice']:
         os.nice(CONFIG['nice'])
@@ -64,8 +82,16 @@ def naive_worker(fun, data, n_split, tol, job_q, result_q):
             return
 
 
-def start_workers(fun, data, n_split, tol, shared_job_q, shared_result_q, nprocs):
-    """sets up workers"""
+def start_workers(
+        fun: Callable[[RegressionData, int, float, float], CVResult],
+        data: RegressionData,
+        n_split: int,
+        tol: float,
+        shared_job_q: Queue,
+        shared_result_q: Queue,
+        nprocs: int,
+) -> list[Process]:
+    """Start worker processes for the current cross-validation sweep."""
     procs = []
     for i in range(nprocs):
         p = Process(
@@ -84,7 +110,7 @@ def crossvalidate(
         n_splits: int,
         n_workers: int = None,
 ) -> List[CVResult]:
-    """used to perform cross-validation of cTRF model
+    """Perform cross-validation over a set of regularization values.
 
     This function assumes `model` class has method _get_cvfunc(data, n_splits)
     which returns a callable. It calls that object with different
@@ -111,7 +137,7 @@ def crossvalidate(
 
     Returns
     -------
-    results : List[CVResult]
+    results
         Cross-validation results.
     """
     prog = tqdm(total=len(mus), desc="Crossvalidation", unit='mu', unit_scale=True)
@@ -148,12 +174,15 @@ def crossvalidate(
 
 
 class TimeSeriesSplit:
-    def __init__(self, r=0.05, p=5, d=100):
+    """Split contiguous time indices into ordered train/test windows."""
+
+    def __init__(self, r: float = 0.05, p: int = 5, d: int = 100):
         self.ratio = r
         self.p = p
         self.d = d
 
-    def _iter_part_masks(self, X):
+    def _iter_part_masks(self, X: Sequence[object] | FloatArray) -> Iterator[tuple[np.ndarray, np.ndarray]]:
+        """Yield boolean masks for each backward-moving validation split."""
         n_v = ceil(self.ratio / (1 + self.ratio) * len(X))
         for i in range(self.p, 0, -1):
             test_mask = np.zeros(len(X), dtype=bool)
@@ -163,9 +192,10 @@ class TimeSeriesSplit:
                 test_mask[-i * n_v:] = True
             else:
                 test_mask[-i * n_v:-(i - 1) * n_v] = True
-            yield (train_mask, test_mask)
+            yield train_mask, test_mask
 
-    def split(self, X):
+    def split(self, X: Sequence[object] | FloatArray) -> Iterator[tuple[np.ndarray, np.ndarray]]:
+        """Yield integer index arrays for each validation split."""
         indices = np.arange(len(X))
         for (train_mask, test_mask) in self._iter_part_masks(X):
             train_index = indices[train_mask]

--- a/ncrf/_crossvalidation.py
+++ b/ncrf/_crossvalidation.py
@@ -137,7 +137,7 @@ def crossvalidate(
 
     Returns
     -------
-    results
+    list
         Cross-validation results.
     """
     prog = tqdm(total=len(mus), desc="Crossvalidation", unit='mu', unit_scale=True)

--- a/ncrf/_fastac.py
+++ b/ncrf/_fastac.py
@@ -1,15 +1,31 @@
+"""FASTA proximal-optimization implementation used inside the NCRF solver.
+
+The higher-level NCRF model constructs the objective for each outer iteration,
+and this module handles the inner forward-backward optimization step that
+updates the temporal response coefficients.
+"""
+
+from __future__ import annotations
+
 # Author: Proloy Das <email:proloyd94@gmail.com>
 # License: BSD (3-clause)
-"""Module implementing the FASTA algorithm"""
 
-import numpy as np
 from math import sqrt
 import time
+from typing import Callable
 
 import logging
 
+import numpy as np
+import numpy.typing as npt
 
-def _next_stepsize(deltax, deltaF):
+FloatArray = npt.NDArray[np.float64]
+ObjectiveFunction = Callable[[FloatArray], float]
+GradientFunction = Callable[[FloatArray], FloatArray]
+ProximalOperator = Callable[[FloatArray, float], FloatArray]
+
+
+def _next_stepsize(deltax: FloatArray, deltaF: FloatArray) -> float:
     """A variation of spectral descent step-size selection: 'adaptive' BB method.
 
     Reference:
@@ -19,10 +35,11 @@ def _next_stepsize(deltax, deltaF):
 
     parameters
     ----------
-    deltax: ndarray
-        difference between coefs_current and coefs_next
-    deltaF: ndarray
-        difference between grad operator evaluated at coefs_current and coefs_next
+    deltax
+        Difference between the current and next coefficient estimates.
+    deltaF
+        Difference between the gradient evaluated at the current and next
+        coefficient estimates.
 
     returns
     -------
@@ -48,8 +65,8 @@ def _next_stepsize(deltax, deltaF):
             return tau_s - 0.5 * tau_m
 
 
-def _compute_residual(deltaf, sg):
-    """Computes residuals"""
+def _compute_residual(deltaf: FloatArray, sg: FloatArray) -> tuple[float, float]:
+    """Compute absolute and relative residuals for the current FASTA step."""
     res = sqrt(((deltaf + sg) ** 2).sum())
     a = sqrt((deltaf ** 2).sum())
     b = sqrt((sg ** 2).sum())
@@ -57,31 +74,40 @@ def _compute_residual(deltaf, sg):
     return res, res_r
 
 
-def _update_coefs(x, tau, gradfx, prox, f, g, beta, fk):
+def _update_coefs(
+        x: FloatArray,
+        tau: float,
+        gradfx: FloatArray,
+        prox: ProximalOperator,
+        f: ObjectiveFunction,
+        g: ObjectiveFunction,
+        beta: float,
+        fk: float,
+) -> tuple[FloatArray, float, FloatArray, float, int]:
     """Non-monotone line search
 
     parameters
     ----------
-    x: ndarray
-        current coefficients
-    tau: float
+    x
+        Current coefficients.
+    tau
         step size
-    gradfx: ndarry
-        gradient operator evaluated at current coefficients
-    prox: function handle
+    gradfx
+        Gradient evaluated at the current coefficients.
+    prox
         proximal operator of :math:`g(x)`
-    f: callable
+    f
         smooth differentiable function, :math:`f(x)`
-    g: callable
+    g
         non-smooth function, :math:`g(x)`
-    beta: float
+    beta
         backtracking parameter
-    fk: float
+    fk
         maximum of previous function values
 
     returns
     -------
-    z: ndarray
+    z
         next coefficients
     """
     x_hat = x - tau * gradfx
@@ -110,41 +136,38 @@ class Fasta:
 
     Parameters
     ----------
-    f: function handle
+    f
         smooth differentiable function, :math:`f(x)`
-    g: function handle
+    g
         non-smooth convex function, :math:`g(x)`
-    gradf: function handle
+    gradf
         gradient of smooth differentiable function, :math:`\\nabla f(x)`
-    proxg: function handle
+    proxg
         proximal operator of non-smooth convex function
-     :math:`proxg(v, \\lambda) = argmin g(x) + \\frac{1}{2*\\lambda}\|x-v\|^2`
-    beta: float, optional
+        :math:`proxg(v, \\lambda) = argmin g(x) + \\frac{1}{2*\\lambda}\|x-v\|^2`
+    beta
         backtracking parameter
         default is 0.5
-    n_iter: int, optional
+    n_iter
         number of iterations
         default is 1000
 
     Attributes
     ----------
-    coefs: ndvar
-        learned coefficients
-    objective_value: float
-        optimum objective value
-    residuals: list
-        residual values at each iteration
-    initial_stepsize: float, optional
-        created only with verbose=1 option
-    objective: list, optional
-        objective values at each iteration
-        created only with verbose=1 option
-    stepsizes: list, optional
-        stepsizes at each iteration
-        created only with verbose=1 option
-    backtracks: list, optional
-        number of backtracking steps
-        created only with verbose=1 option
+    coefs
+        Learned coefficients.
+    objective_value
+        Optimum objective value.
+    residuals
+        Residual values at each iteration.
+    initial_stepsize
+        Initial step size, created only with ``verbose=1``.
+    objective
+        Objective values at each iteration, created only with ``verbose=1``.
+    stepsizes
+        Step sizes at each iteration, created only with ``verbose=1``.
+    backtracks
+        Number of backtracking steps, created only with ``verbose=1``.
 
     Notes
     -----
@@ -168,39 +191,41 @@ class Fasta:
     >>> lsq.learn(x0, verbose=1)
     """
 
-    def __init__(self, f, g, gradf, proxg, beta=0.5, n_iter=1000):
+    def __init__(
+            self,
+            f: ObjectiveFunction,
+            g: ObjectiveFunction,
+            gradf: GradientFunction,
+            proxg: ProximalOperator,
+            beta: float = 0.5,
+            n_iter: int = 1000,
+    ):
         self.f = f
         self.g = g
         self.grad = gradf
         self.prox = proxg
         self.beta = beta
         self.n_iter = n_iter
-        self.residuals = []
-        self._funcValues = []
-        self.coefs_ = None
+        self.residuals: list[float] = []
+        self._funcValues: list[float] = []
+        self.coefs_: FloatArray | None = None
 
-    def __str__(self):
-        return "Fast adaptive shrinkage/thresholding Algorithm instance"
+    def __str__(self) -> str:
+        return "<Fast adaptive shrinkage/thresholding Algorithm instance>"
 
-    def learn(self, coefs_init, tol=1e-2, verbose=True):
-        """fits the model using FASTA algorithm
+    def learn(self, coefs_init: FloatArray, tol: float = 1e-2, verbose: bool = True) -> Fasta:
+        """Fit the coefficients using the FASTA algorithm.
 
-        parameters
+        Parameters
         ----------
-        coefs_init: ndarray
+        coefs_init
             initial guess
-
-        tol: float, optional
+        tol
             tolerance parameter
             default is 1e-8
-
-        verbose: {0,1}
+        verbose
             verbosity of the method : 1 will display informations while 0 will display nothing
             default = 0
-
-        returns
-        -------
-        self
         """
         logger = logging.getLogger("FASTA")
         coefs_current = np.copy(coefs_init)
@@ -260,4 +285,4 @@ class Fasta:
         self.coefs_ = coefs_current
         self.objective_value = objective_next + self.g(coefs_current)
         if verbose:
-            logger.debug(f"total time elapsed : {end - start}s")
+            logger.debug(f"total time elapsed : {end - start:.3f} s")

--- a/ncrf/_fastac.py
+++ b/ncrf/_fastac.py
@@ -33,7 +33,7 @@ def _next_stepsize(deltax: FloatArray, deltaF: FloatArray) -> float:
     B. Zhou, L. Gao, and Y.H. Dai, 'Gradient methods with adaptive step-sizes,'
     Comput. Optim. Appl., vol. 35, pp. 69-86, Sept. 2006
 
-    parameters
+    Parameters
     ----------
     deltax
         Difference between the current and next coefficient estimates.
@@ -41,10 +41,10 @@ def _next_stepsize(deltax: FloatArray, deltaF: FloatArray) -> float:
         Difference between the gradient evaluated at the current and next
         coefficient estimates.
 
-    returns
+    Returns
     -------
     float
-        adaptive step-size
+        Adaptive step-size.
     """
     n_deltax = (deltax ** 2).sum()  # linalg.norm(deltax, 'fro') ** 2
     n_deltaF = (deltaF ** 2).sum()  # linalg.norm(deltaF, 'fro') ** 2
@@ -86,7 +86,7 @@ def _update_coefs(
 ) -> tuple[FloatArray, float, FloatArray, float, int]:
     """Non-monotone line search
 
-    parameters
+    Parameters
     ----------
     x
         Current coefficients.
@@ -105,10 +105,12 @@ def _update_coefs(
     fk
         maximum of previous function values
 
-    returns
+    Returns
     -------
-    z
-        next coefficients
+    tuple
+        Tuple ``(z, fz, sg, tau, count)`` containing the updated coefficients,
+        objective value, subgradient term, accepted step size, and number of
+        backtracking steps.
     """
     x_hat = x - tau * gradfx
     z = prox(x_hat, tau)

--- a/ncrf/_model.py
+++ b/ncrf/_model.py
@@ -500,7 +500,7 @@ class RegressionData:
 
 
 class NCRF:
-    """The object-based API for cortical TRF localization.
+    """Result container and object-based API for NCRF.
 
     Parameters
     ----------

--- a/ncrf/_model.py
+++ b/ncrf/_model.py
@@ -1,6 +1,14 @@
+"""Core data structures and optimization logic for NCRF estimation.
+
+``RegressionData`` turns Eelbrain objects into normalized numeric arrays with a
+stable internal layout, and :class:`NCRF` consumes that prepared data to run
+the alternating Bayesian/source-estimation procedure.
+"""
 # Authors: Proloy Das <email:proloyd94@gmail.com>
 #          Christian Brodbeck <email:brodbecc@mcmaster.ca>
 # License: BSD (3-clause)
+from __future__ import annotations
+
 import time
 import copy
 import collections
@@ -8,10 +16,11 @@ from functools import cached_property
 from math import sqrt, log10
 from multiprocessing import current_process
 from operator import attrgetter
-from typing import Iterator, Sequence, Union
+from typing import Any, Callable, Iterator, Literal, Sequence
 
-from eelbrain import fmtxt, UTS, NDVar
+from eelbrain import NDVar, UTS, fmtxt
 import numpy as np
+import numpy.typing as npt
 from scipy import linalg
 from scipy.signal import find_peaks
 from tqdm import tqdm
@@ -25,26 +34,39 @@ import logging
 
 
 _R_tol = np.finfo(np.float64).eps * 1e2
-MuArg = Union[float, Sequence[float], str]
-MusArg = Union[Sequence[float], str]
+FloatArray = npt.NDArray[np.float64]
+IndexArray = npt.NDArray[np.int64]
+TrialData = tuple[FloatArray, FloatArray]
+ObjectiveFunction = Callable[[FloatArray], float]
+GradientFunction = Callable[[FloatArray], FloatArray]
+MuArg = float | Sequence[float] | Literal["auto"]
+MusArg = Sequence[float] | Literal["auto"] | None
 
 
-def gaussian_basis(nlevel, span, stds=8.5):
+def gaussian_basis(
+        nlevel: int,
+        span: npt.ArrayLike,
+        stds: float = 8.5,
+) -> FloatArray:
     """Construct Gabor basis for the TRFs.
 
     Parameters
     ----------
-    nlevel: int
+    nlevel
         number of atoms
-    span: ndarray
-        the span to cover by the atoms
+    span
+        One-dimensional sample locations covered by the basis functions.
+    stds
+        Standard deviation of each Gaussian atom, expressed in the same units
+        as ``span``.
 
     Returns
     -------
-        ndarray (Gabor atoms)
+    basis
+        Array whose columns contain the basis atoms.
     """
     logger = logging.getLogger(__name__)
-    x = span
+    x = np.asarray(span, dtype=np.float64)
     means = np.linspace(x[0] + x[-1] / nlevel, x[-1] * (1 - 1 / nlevel), num=nlevel - 1)
     logger.info(f'Using gaussian std = {stds}')
     W = []
@@ -57,23 +79,23 @@ def gaussian_basis(nlevel, span, stds=8.5):
     return W.T / np.max(W)
 
 
-def g(x, mu):
-    """vector l1-norm penalty"""
+def g(x: FloatArray, mu: float) -> float:
+    """Vector l1-norm penalty."""
     return mu * np.sum(np.abs(x))
 
 
-def proxg(x, mu, tau):
-    """proximal operator for l1-norm penalty"""
+def proxg(x: FloatArray, mu: float, tau: float) -> FloatArray:
+    """Proximal operator for the l1-norm penalty."""
     return shrink(x, mu * tau)
 
 
-def shrink(x, mu):
-    """Soft theresholding function"""
+def shrink(x: FloatArray, mu: float) -> FloatArray:
+    """Soft-thresholding operator."""
     return np.multiply(np.sign(x), np.maximum(np.abs(x) - mu, 0))
 
 
-def g_group(x, mu):
-    r"""group (l12) norm  penalty:
+def g_group(x: FloatArray, mu: float) -> float:
+    r"""group (l12) norm penalty:
 
             gg(x) = \sum ||x_s_{i,t}||
 
@@ -86,7 +108,7 @@ def g_group(x, mu):
     return val
 
 
-def proxg_group_opt(z, mu):
+def proxg_group_opt(z: FloatArray, mu: float) -> FloatArray:
     """proximal operator for gg(x):
 
             prox_{mu gg}(x) = min  gg(z) + 1/ (2 * mu) ||x-z|| ** 2
@@ -102,21 +124,26 @@ def proxg_group_opt(z, mu):
     return z
 
 
-def covariate_from_stim(stims, Ms, starts):
-    """Form covariate matrix from stimulus
+def covariate_from_stim(
+        stims: Sequence[NDVar] | NDVar,
+        Ms: Sequence[int] | npt.ArrayLike,
+        starts: Sequence[int] | npt.ArrayLike,
+) -> list[FloatArray]:
+    """Form lagged covariate matrices from one or more stimulus NDVars.
 
     parameters
     ----------
-    stims : list of NDVar
-        Predictor variables.
-    Ms : list of int
-        Order of filters.
-    start : list of int
-        Starting times for TRFs (in samples)
+    stims
+        Predictor variables. Each predictor must provide a ``time`` axis and may have
+        at most one additional feature dimension before time.
+    Ms
+        Filter lengths, in samples, for each expanded predictor channel.
+    start
+        Start offsets, in samples, for each expanded predictor channel.
 
     returns
     -------
-    x : list of ndarray
+    x
         Covariate matrices.
     """
     ws = []
@@ -150,8 +177,8 @@ def covariate_from_stim(stims, Ms, starts):
     return Y
 
 
-def _myinv(x):
-    """Computes inverse"""
+def _myinv(x: FloatArray) -> FloatArray:
+    """Compute a tolerance-aware elementwise reciprocal."""
     x = np.real(np.array(x))
     tol = _R_tol * x.max()
     ind = (x > tol)
@@ -160,7 +187,10 @@ def _myinv(x):
     return y
 
 
-def _inv_sqrtm(m, return_eig=False):
+def _inv_sqrtm(
+        m: FloatArray,
+        return_eig: bool = False,
+) -> FloatArray | tuple[FloatArray, FloatArray]:
     e, v = linalg.eigh(m)
     e = e.real
     tol = _R_tol * e.max()
@@ -172,7 +202,7 @@ def _inv_sqrtm(m, return_eig=False):
     return np.sqrt(y) * v.T.conj()
 
 
-def _compute_gamma_i(z, x):
+def _compute_gamma_i(z: FloatArray, x: FloatArray) -> FloatArray:
     """Computes Gamma_i
 
     Gamma_i = Z**(-1/2) * ( Z**(1/2) X X' Z**(1/2)) ** (1/2) * Z**(-1/2)
@@ -182,14 +212,15 @@ def _compute_gamma_i(z, x):
 
     Parameters
     ----------
-    z: ndarray
-        auxiliary variable,  z_i
-    x: ndarray
-        auxiliary variable, x_i
+    z
+        Auxiliary matrix for one source block.
+    x
+        Auxiliary coefficients for the same source block.
 
     Returns
     -------
-        ndarray
+    gamma
+        Updated block covariance matrix.
     """
     [e, v] = linalg.eig(z)
     e = e.real
@@ -205,7 +236,7 @@ def _compute_gamma_i(z, x):
     return np.array(np.real(np.dot(temp * d, temp.conj().T)))
 
 
-def _compute_gamma_ip(z, x, gamma):
+def _compute_gamma_ip(z: FloatArray, x: FloatArray, gamma: FloatArray) -> None:
     """Wrapper function of Cython function 'compute_gamma_c'
 
     Computes Gamma_i = Z**(-1/2) * ( Z**(1/2) X X' Z**(1/2)) ** (1/2) * Z**(-1/2)
@@ -215,13 +246,12 @@ def _compute_gamma_ip(z, x, gamma):
 
     Parameters
     ----------
-    z : ndarray
-        array of shape (dc, dc)
-        auxiliary variable,  z_i
-    x : ndarray
-        auxiliary variable, x_i
-    gamma : ndarray
-        place where Gamma_i is updated
+    z
+        Auxiliary square matrix for one source block, usually of shape ``(dc, dc)``.
+    x
+        Auxiliary coefficients for the same source block.
+    gamma
+        Output array that is updated in place with the new block covariance.
     """
     assert x.shape[0] == 3
     a = np.dot(x, x.T)
@@ -230,35 +260,42 @@ def _compute_gamma_ip(z, x, gamma):
 
 
 class RegressionData:
-    """Data Container for regression problem
+    """Prepared regression dataset for NCRF fitting.
 
     Parameters
     ----------
     tstart
-        Start of the TRF in seconds. Can define multiple tstarts for more than 1 predictor.
+        Start of the TRF in seconds. A scalar applies to all predictors; a sequence
+        specifies one start time per predictor.
     tstop
-        Stop of the TRF in seconds. Can define multiple tstops for more than 1 predictor.
+        Stop of the TRF in seconds. A scalar applies to all predictors; a sequence
+        specifies one stop time per predictor.
     nlevel
         Decides the density of Gabor atoms. Bigger nlevel -> less dense basis.
-        By default it is set to 1. ``nlevel > 2`` should be used with caution.
+        By default, it is set to 1. ``nlevel > 2`` should be used with caution.
     baseline
-        Mean that will be subtracted from ``stim``.
+        Per-predictor means to subtract from ``stim`` before covariate construction.
     scaling
-        Scale by which ``stim`` was divided.
+        Per-predictor scaling factors applied after baseline subtraction.
+    stim_is_single
+        Records whether the original stimulus input was passed as a single predictor
+        per segment or as an explicit collection of predictors.
+    gaussian_fwhm
+        Full width at half maximum of the Gaussian basis functions, in milliseconds.
     """
     _n_predictor_variables = 1
     _prewhitened = None
 
     def __init__(
             self,
-            tstart: Union[float, list[float]],
-            tstop: Union[float, list[float]],
-            nlevel: int = 1,
-            baseline: list[float] = None,
-            scaling: list[float] = None,
-            stim_is_single: bool = None,
+            tstart: float | Sequence[float],
+            tstop: float | Sequence[float],
+            nlevel: int,
+            baseline: Sequence[NDVar | float] | None,
+            scaling: Sequence[NDVar | float] | None,
+            stim_is_single: bool,
             gaussian_fwhm: float = 20.0,
-    ):
+    ) -> None:
         self.tstart = tstart if isinstance(tstart, collections.abc.Sequence) else [tstart]
         self.tstop = tstop if isinstance(tstop, collections.abc.Sequence) else [tstop]
         self.nlevel = nlevel
@@ -277,17 +314,24 @@ class RegressionData:
         self.sensor_dim = None
         self.gaussian_fwhm = gaussian_fwhm
 
-    def add_data(self, meg, stim):
-        """Add sensor measurements and predictor variables for one trial
+    def add_data(
+            self,
+            meg: NDVar,
+            stim: Sequence[NDVar] | NDVar,
+    ) -> None:
+        """Add sensor measurements and predictor variables for one trial.
 
         Call this function repeatedly to add data for multiple trials/recordings
 
         Parameters
         ----------
-        meg : NDVar  (sensor, UTS)
-            MEG Measurements.
-        stim : list of NDVar  ([...,] UTS)
-            One or more predictor variable. The time axis needs to match ``y``.
+        meg
+            MEG measurements for one contiguous segment, with ``sensor`` and ``time``
+            dimensions.
+        stim
+            One or more predictor variables whose ``time`` axis matches ``meg``.
+            Each predictor can be one-dimensional over time or carry one feature
+            dimension before time.
         """
         if self.sensor_dim is None:
             self.sensor_dim = meg.get_dim('sensor')
@@ -381,8 +425,8 @@ class RegressionData:
         x = np.concatenate(covariates, axis=1).astype(np.float64)
         self.covariates.append(x)
 
-    def _prewhiten(self, whitening_filter):
-        """Called by NCRF instance"""
+    def _prewhiten(self, whitening_filter: FloatArray) -> None:
+        """Apply the model's whitening filter to all stored MEG segments."""
         if self._prewhitened is None:
             for i, (meg, _) in enumerate(self):
                 self.meg[i] = np.dot(whitening_filter, meg)
@@ -390,8 +434,8 @@ class RegressionData:
         else:
             pass
 
-    def _precompute(self):
-        """Called by NCRF instance"""
+    def _precompute(self) -> None:
+        """Cache quadratic forms reused during repeated objective evaluation."""
         self._bbt = []
         self._bE = []
         self._EtE = []
@@ -400,24 +444,27 @@ class RegressionData:
             self._bE.append(np.dot(b, E))
             self._EtE.append(np.dot(E.T, E))
 
-    def __iter__(self) -> Iterator[tuple[np.ndarray, np.ndarray]]:
+    def __iter__(self) -> Iterator[TrialData]:
         return zip(self.meg, self.covariates)
 
-    def __len__(self):
+    def __len__(self) -> int:
         return len(self.meg)
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return 'Regression data'
 
-    def timeslice(self, idx):
-        """gets a time slice (used for cross-validation)
+    def timeslice(self, idx: Sequence[int] | IndexArray) -> RegressionData:
+        """Return a new dataset restricted to selected time indices.
 
         Parameters
         ----------
-        idx : kfold splits
+        idx
+            Integer indices selecting the time samples to retain.
+
         Returns
         -------
-            REG_Data instance
+        data
+            A new dataset containing the requested time slice.
         """
         obj = type(self).__new__(self.__class__)
         # take care of the copied values from the old_obj
@@ -437,7 +484,8 @@ class RegressionData:
 
         return obj
 
-    def post_normalization(self):
+    def post_normalization(self) -> None:
+        """Equalize covariate scales across predictor blocks after construction."""
         n_vars = sum(len(dim) if dim else 1 for dim in self._stim_dims)
         if n_vars > 1:
             start = 0
@@ -456,40 +504,40 @@ class NCRF:
 
     Parameters
     ----------
-    lead_field : eelbrain.NDVar
-        forward solution a.k.a. lead_field matrix.
-    noise_covariance : np.ndarray
-        noise covariance matrix, use empty-room recordings to generate noise covariance
-        matrix at sensor space.
-    n_iter : int
+    lead_field
+        Forward solution a.k.a. lead-field matrix, with ``sensor`` and ``source``
+        dimensions and an optional ``space`` dimension for free orientation.
+    noise_covariance
+        Noise covariance matrix in sensor space, typically estimated from empty-room
+        recordings.
+    n_iter
         Number of out iterations of the algorithm, by default set to 10.
-    n_iterc : int
+    n_iterc
         Number of Champagne iterations within each outer iteration, by default set to 30.
-    n_iterf : int
+    n_iterf
         Number of FASTA iterations within each outer iteration, by default set to 100.
 
     Attributes
     ----------
-    h : NDVar | tuple of NDVar
-        the neuro-current response function. Whether ``h`` is an NDVar or a tuple of
-        NDVars depends on whether the ``x`` parameter to :func:`ncrf` was
-        an NDVar or a sequence of NDVars.
-    explained_var: float
-        fraction of total variance explained by ncrfs
-    voxelwise_explained_variance: NDVar
-        fractions of total variance explained by individual voxel ncrf
-    Gamma: list
-        individual source covariance matrices
-    sigma_b: list of ndarray
-        data covariances under the model
-    theta: ndarray
-        ncrf coefficients over Gabor basis.
-    residual : float | NDVar
+    h
+        The neuro-current response function. It is one NDVar when fitting a single
+        predictor and a sequence of NDVars when fitting multiple predictors.
+    explained_var
+        Fraction of total variance explained by the fitted NCRFs.
+    voxelwise_explained_variance
+        Source-wise contributions to explained variance.
+    Gamma
+        Individual source covariance matrices.
+    sigma_b
+        Data covariance estimates under the model.
+    theta
+        NCRF coefficients over the Gabor basis.
+    residual
         The fit error, i.e. the result of the ``eval_obj`` error function on the
         final fit.
-    stim_baseline: NDVar| float| list | None
+    stim_baseline
         Mean that was subtracted from ``stim``.
-    stim_scaling: NDVar| float| list | None
+    stim_scaling
         Scale by which ``stim`` was divided.
 
     Notes
@@ -525,7 +573,14 @@ class NCRF:
     theta = None
     gaussian_fwhm = None
 
-    def __init__(self, lead_field, noise_covariance, n_iter=30, n_iterc=10, n_iterf=100):
+    def __init__(
+            self,
+            lead_field: NDVar,
+            noise_covariance: FloatArray,
+            n_iter: int = 30,
+            n_iterc: int = 10,
+            n_iterf: int = 100,
+    ) -> None:
         if lead_field.has_dim('space'):
             g = lead_field.get_data(dims=('sensor', 'source', 'space')).astype(np.float64)
             self.lead_field = g.reshape(g.shape[0], -1)
@@ -545,15 +600,15 @@ class NCRF:
         # self._init_vars()
         self._whitening_filter = None
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         if self.space:
             orientation = 'free'
         else:
             orientation = 'fixed'
-        out = "<[%s orientation] %s on %r>" % (orientation, self._name, self.source)
-        return out
+        return f"<[{orientation} orientation] {self._name} on {self.source!r}>"
 
-    def __copy__(self):
+    def __copy__(self) -> NCRF:
+        """Create a shallow copy with configuration but without fit results."""
         obj = type(self).__new__(self.__class__)
         copy_keys = ['lead_field', 'lead_field_scaling', 'source', 'space', 'sensor', '_whitening_filter',
                      'noise_covariance', 'n_iter', 'n_iterc', 'n_iterf', 'eta', 'init_sigma_b', 'gaussian_fwhm']
@@ -567,10 +622,12 @@ class NCRF:
                      'residual', 'source', 'space', 'theta', 'tstart', 'tstep', 'tstop', 'gaussian_fwhm',
                      '_stim_normalization', '_whitening_filter')
 
-    def __getstate__(self):
+    def __getstate__(self) -> dict[str, Any]:
+        """Serialize the fitted model state needed for pickling."""
         return {k: getattr(self, k) for k in self._PICKLE_ATTRS}
 
-    def __setstate__(self, state):
+    def __setstate__(self, state: dict[str, Any]) -> None:
+        """Restore pickled state while keeping compatibility with older versions."""
         for k in self._PICKLE_ATTRS:
             setattr(self, k, state.get(k, None))
         # make compatible with one tstop case
@@ -595,7 +652,8 @@ class NCRF:
         if self.gaussian_fwhm is None:
             self.gaussian_fwhm = 20.0  # the default value
 
-    def _prewhiten(self):
+    def _prewhiten(self) -> None:
+        """Prewhiten the lead field and noise model before fitting."""
         wf = _inv_sqrtm(self.noise_covariance)
         wf_var = np.var(wf, axis=1)
         zero_var_wf = wf_var == 0
@@ -614,7 +672,8 @@ class NCRF:
         # sigma_b = self.noise_covariance + self.eta * np.dot(self.lead_field, self.lead_field.T)
         # self.init_sigma_b = sigma_b
 
-    def _init_from_mne(self, data):
+    def _init_from_mne(self, data: RegressionData) -> None:
+        """Seed source variances from a minimum-norm style initialization."""
         eta = []
         sigma_b = []
         dc = len(self.space) if self.space else 1
@@ -627,7 +686,8 @@ class NCRF:
         self.eta = eta
         self.init_sigma_b = sigma_b
 
-    def _init_iter(self, data):
+    def _init_iter(self, data: RegressionData) -> None:
+        """Initialize solver state for a new value of the regularization parameter."""
         if self.space:
             dc = len(self.space)
         else:
@@ -646,22 +706,29 @@ class NCRF:
         l = sum([basis.shape[1] * (len(dim) if dim else 1) for basis, dim in zip(data.basis, data._stim_dims)])
         self.theta = np.zeros((len(self.source) * dc, l), dtype=np.float64)
 
-    def _set_mu(self, mu, data):
+    def _set_mu(self, mu: float, data: RegressionData) -> None:
+        """Reset the solver state for the requested regularization value."""
         self.mu = mu
         self._init_iter(data)
         data._precompute()
         if mu == 0.0:
             self._solve(data, self.theta, n_iterc=30)
 
-    def _solve(self, data, theta, idx=slice(None, None), n_iterc=None):
+    def _solve(
+            self,
+            data: RegressionData,
+            theta: FloatArray,
+            idx: slice | IndexArray = slice(None, None),
+            n_iterc: int | None = None,
+    ) -> None:
         """Champagne steps implementation
 
         Parameters
         ----------
-        data : RegressionData
-            regression data to fit.
-        theta : ndarray
-            co-effecients of the TRFs over Gabor atoms.
+        data
+            Prepared regression data to fit.
+        theta
+            Coefficients of the TRFs over the Gabor basis.
 
         Notes
         -----
@@ -766,8 +833,8 @@ class NCRF:
             n_splits: int = None,
             n_workers: int = None,
             compute_explained_variance: bool = False,
-    ):
-        """Fit NCRF model to data
+    ) -> None:
+        """Fit the NCRF model to prepared regression data.
 
         Estimate both TRFs and source variance from the observed MEG data by solving
         the Bayesian optimization problem formulated in :cite:`das2020neuro`.
@@ -778,7 +845,7 @@ class NCRF:
             M/EEG data and the corresponding stimulus variables.
         mu
             Regularization parameter; promote sparsity and guard against over-fitting
-        do_crossvalidation : bool
+        do_crossvalidation
             if True, from a wide range of regularizing parameters, the one resulting in
             the least generalization error in a k-fold cross-validation procedure is chosen.
             Unless specified the range and k is chosed from cofig.py. The user can also pass
@@ -786,8 +853,7 @@ class NCRF:
         tol
             tolerence parameter. Decides when to stop outer iterations.
         verbose
-            If set True prints intermediate values of the cost functions.
-            by Default it is set to be False
+            If set True prints intermediate values of the cost functions (default ``False``).
         use_ES
             use estimation stability criterion :cite:`limEstimationStabilityCrossValidation2016`
             to choose the best ``mu`` (default ``False``).
@@ -911,8 +977,8 @@ class NCRF:
             self._voxelwise_explained_variance = self._compute_voxelwise_explained_variance(data)
         self._data = data  # save the data for further use
 
-    def _copy_from_data(self, data):
-        "copies relevant fields from data"
+    def _copy_from_data(self, data: RegressionData) -> None:
+        """Copy stimulus metadata needed to rebuild Eelbrain output objects."""
         self._stim_is_single = data._stim_is_single
         self._stim_dims = data._stim_dims
         self._stim_names = data._stim_names
@@ -925,13 +991,13 @@ class NCRF:
         self.tstop = data.tstop
         self.gaussian_fwhm = data.gaussian_fwhm
 
-    def _construct_f(self, data):
-        """creates instances of objective function and its gradient to be passes to the FASTA algorithm
+    def _construct_f(self, data: RegressionData) -> tuple[ObjectiveFunction, GradientFunction]:
+        """Build the smooth objective and gradient passed to FASTA.
 
         Parameters
         ---------
-        data : RegressionData
-            Data.
+        data
+            Prepared regression data.
         """
         leadfields = []
         bEs = []
@@ -972,17 +1038,23 @@ class NCRF:
 
         return funct, grad_funct
 
-    def eval_obj(self, data, return_wl2=False):
-        """evaluates objective function
+    def eval_obj(
+            self,
+            data: RegressionData,
+            return_wl2: bool = False,
+    ) -> float | tuple[float, float]:
+        """Evaluate the current objective value on a dataset.
 
         Parameters
         ---------
-        data : RegressionData
-            Data.
+        data
+            Dataset on which to evaluate the objective.
 
         Returns
         -------
-            float
+        value
+            Objective value, or a tuple with the weighted L2 term when
+            ``return_wl2`` is true.
         """
         ll2 = 0
         logdet = 0
@@ -1017,17 +1089,8 @@ class NCRF:
             return (ll2 + logdet) / len(data), ll2 / len(data)
         return (ll2 + logdet) / len(data)
 
-    def eval_l2(self, data):
-        """evaluates Theta cross-validation metric (used by CV only)
-
-        Parameters
-        ---------
-        data : REG_Data instance
-
-        Returns
-        -------
-            float
-        """
+    def eval_l2(self, data: RegressionData) -> float:
+        """Evaluate the unweighted L2 prediction error used in CV."""
         l2 = 0
         for key, (meg, covariate) in enumerate(data):
             y = meg - np.dot(np.dot(self.lead_field, self.theta), covariate.T)
@@ -1035,17 +1098,8 @@ class NCRF:
 
         return l2 / len(data)
 
-    def compute_explained_variance(self, data):
-        """evaluates explained_variance
-
-        Parameters
-        ---------
-        data : REG_Data instance
-
-        Returns
-        -------
-            float
-        """
+    def compute_explained_variance(self, data: RegressionData) -> float:
+        """Compute the global explained-variance score for a fitted model."""
         logger = logging.getLogger('NCRF: Explained Variance')
         temp = 0
         for key, (meg, covariate) in enumerate(data):
@@ -1061,18 +1115,8 @@ class NCRF:
         logger.debug(f'{self.mu}: {1 - temp / len(data)}')
         return 1 - temp / len(data)
 
-    def _compute_voxelwise_explained_variance(self, data: RegressionData):
-        """evaluates explained_variance
-
-        Parameters
-        ---------
-        data
-            Regression data.
-
-        Returns
-        -------
-            float
-        """
+    def _compute_voxelwise_explained_variance(self, data: RegressionData) -> FloatArray:
+        """Compute each source's contribution to explained variance."""
         temp = np.zeros(len(self.source))
         theta = self.theta.copy()
         for key, (meg, covariate) in enumerate(data):
@@ -1097,16 +1141,16 @@ class NCRF:
         return temp / len(data)
 
     @cached_property
-    def voxelwise_explained_variance(self):
-        """voxelwise_explained_variance"""
+    def voxelwise_explained_variance(self) -> NDVar | None:
+        """Voxelwise explained variance expressed on the source dimension."""
         if self._voxelwise_explained_variance is None:
             return None
         else:
             return NDVar(self._voxelwise_explained_variance, self.source)
 
     @cached_property
-    def h_scaled(self):
-        """h with original stimulus scale restored"""
+    def h_scaled(self) -> NDVar | list[NDVar]:
+        """Return ``h`` with the original stimulus scaling restored."""
         if self._stim_scaling is None:
             return self.h
         elif self._stim_is_single:
@@ -1115,8 +1159,8 @@ class NCRF:
             return [h * s for h, s in zip(self.h, self._stim_scaling)]
 
     @cached_property
-    def h(self):
-        """The spatio-temporal response function as (list of) NDVar"""
+    def h(self) -> NDVar | list[NDVar]:
+        """Return the spatio-temporal response function as Eelbrain NDVars."""
         n_vars = sum(len(dim) if dim else 1 for dim in self._stim_dims)
         if self.space:
             _shared_dims = (self.source, self.space)
@@ -1159,7 +1203,7 @@ class NCRF:
             return h
 
     @staticmethod
-    def _residual(theta0, theta1):
+    def _residual(theta0: FloatArray, theta1: FloatArray) -> float:
         diff = theta1 - theta0
         num = diff ** 2
         den = theta0 ** 2
@@ -1169,8 +1213,8 @@ class NCRF:
             return sqrt(num.sum() / den.sum())
 
     @staticmethod
-    def compute_ES_metric(models, data):
-        """Computes estimation stability metric
+    def compute_ES_metric(models: Sequence[NCRF], data: RegressionData) -> float:
+        """Compute the estimation-stability metric across cross-validation folds.
 
         Details can be found at:
         Lim, Chinghway, and Bin Yu. "Estimation stability with cross-validation (ESCV)."
@@ -1178,12 +1222,15 @@ class NCRF:
 
         Parameters
         ----------
-        models : DstRf instances
-        data : REG_Data instances
+        models
+            Fitted models from different cross-validation folds.
+        data
+            Dataset used to compare their predictions.
 
         Returns
         -------
-            float (estimation stability metric)
+        metric
+            Estimation-stability score.
         """
         Y = []
         for model in models:
@@ -1199,29 +1246,37 @@ class NCRF:
         else:
             return VarY / (Y_bar ** 2).sum()
 
-    def cvfunc(self, data, n_splits, tol, mu):
+    def cvfunc(self, data: RegressionData, n_splits: int, tol: float, mu: float) -> CVResult:
         cvfun = self._get_cvfunc(data, n_splits, tol)
         return cvfun(mu)
 
-    def _get_cvfunc(self, data, n_splits, tol):
-        """Method for creating function for crossvalidation
+    def _get_cvfunc(
+            self,
+            data: RegressionData,
+            n_splits: int,
+            tol: float,
+    ) -> Callable[[float], CVResult]:
+        """Create the callable executed by cross-validation workers.
 
         In the cross-validation phase the workers will call this function for
-        for different regularizer parameters.
+        different regularizer parameters.
 
         Parameters
         ----------
-        data : object
-            the instance should be compatible for fitting the model. In addition to
-            that it shall have a timeslice method compatible to kfold objects.
-        n_splits : int
+        data
+            Dataset object compatible with model fitting and exposing
+            :meth:`timeslice` for train/test partitioning.
+        n_splits
             number of folds for cross-validation, If None, it will use values
             specified in config.py.
-        tol : float
+        tol
             tolerence parameter. Decides when to stop outer iterations.
+
         Returns
         -------
-            callable, return the cross-validation metrics
+        cvfunc
+            Callable that evaluates one regularization value and returns the
+            cross-validation metrics.
         """
         models_ = [copy.copy(self) for _ in range(n_splits)]
         # from sklearn.model_selection import KFold
@@ -1254,7 +1309,8 @@ class NCRF:
 
         return cvfunc
 
-    def _auto_mu(self, data, p=99.0):
+    def _auto_mu(self, data: RegressionData, p: float = 99.0) -> FloatArray:
+        """Infer a candidate regularization grid from the gradient magnitudes."""
         self._set_mu(0.0, data)
         _, grad_funct = self._construct_f(data)
         if self.space:
@@ -1270,7 +1326,8 @@ class NCRF:
         lo = hi - 2
         return np.logspace(lo, hi, 7)
 
-    def cv_info(self):
+    def cv_info(self) -> fmtxt.Table:
+        """Summarize stored cross-validation scores in a table."""
         if self._cv_results is None:
             raise ValueError("CV: no cross-validation was performed. Use mu='auto' to perform cross-validation.")
         cv_results = sorted(self._cv_results, key=attrgetter('mu'))
@@ -1298,12 +1355,12 @@ class NCRF:
             table.caption(f"Warnings: {'; '.join(warnings)}")
         return table
 
-    def cv_mu(self, criterion='cross-fit'):
+    def cv_mu(self, criterion: str = 'cross-fit') -> float:
         """Retrieve best mu based on cross-validation
 
         Parameters
         ----------
-        criterion : str
+        criterion
             Criterion for best fit. Possible values:
 
             - ``'cross-fit'``: The smallest cross-fit value (default)
@@ -1328,18 +1385,14 @@ class NCRF:
 
 
 # Functions used for initialize \Gamma
-def find_mu(s, y, eta=1, tol=1e-8, max_iter=1000):
-    """
-
-    :param s: singular values
-    :param y: data whitened by left eigen matrix of svd of L
-            y |-> u.T @ y
-    :param eta: SNR
-        if prewhitened use 1.
-    :param tol:
-    :param max_iter:
-    :return: mu, float
-    """
+def find_mu(
+        s: FloatArray,
+        y: FloatArray,
+        eta: float = 1,
+        tol: float = 1e-8,
+        max_iter: int = 1000,
+) -> float:
+    """Solve for the empirical-Bayes noise parameter used in initialization."""
     logger = logging.getLogger(__name__)
     e = s ** 2
     z = y ** 2
@@ -1366,7 +1419,13 @@ def find_mu(s, y, eta=1, tol=1e-8, max_iter=1000):
     return mu
 
 
-def wls(y, l, w, return_ecov=False):
+def wls(
+        y: FloatArray,
+        l: FloatArray,
+        w: FloatArray,
+        return_ecov: bool = False,
+) -> tuple[FloatArray, float] | tuple[FloatArray, float, FloatArray]:
+    """Solve the weighted least-squares problem used for NCRF initialization."""
     w = np.squeeze(w)
     if w.ndim == 1:
         lw = l * w[None, :]
@@ -1401,7 +1460,13 @@ def wls(y, l, w, return_ecov=False):
     return im @ yw, mu
 
 
-def mne_initialization(y, l, use_depth_prior=True, exp=0.8):
+def mne_initialization(
+        y: FloatArray,
+        l: FloatArray,
+        use_depth_prior: bool = True,
+        exp: float = 0.8,
+) -> tuple[FloatArray, FloatArray]:
+    """Build the initial Gamma and sensor covariance from an MNE-style estimate."""
     N, M = l.shape
     T = y.shape[1]
 

--- a/ncrf/_model.py
+++ b/ncrf/_model.py
@@ -62,7 +62,7 @@ def gaussian_basis(
 
     Returns
     -------
-    basis
+    ndarray
         Array whose columns contain the basis atoms.
     """
     logger = logging.getLogger(__name__)
@@ -219,7 +219,7 @@ def _compute_gamma_i(z: FloatArray, x: FloatArray) -> FloatArray:
 
     Returns
     -------
-    gamma
+    ndarray
         Updated block covariance matrix.
     """
     [e, v] = linalg.eig(z)
@@ -463,7 +463,7 @@ class RegressionData:
 
         Returns
         -------
-        data
+        :class:`RegressionData`
             A new dataset containing the requested time slice.
         """
         obj = type(self).__new__(self.__class__)
@@ -1052,7 +1052,7 @@ class NCRF:
 
         Returns
         -------
-        value
+        float or tuple of float
             Objective value, or a tuple with the weighted L2 term when
             ``return_wl2`` is true.
         """
@@ -1229,7 +1229,7 @@ class NCRF:
 
         Returns
         -------
-        metric
+        float
             Estimation-stability score.
         """
         Y = []
@@ -1274,7 +1274,7 @@ class NCRF:
 
         Returns
         -------
-        cvfunc
+        callable
             Callable that evaluates one regularization value and returns the
             cross-validation metrics.
         """

--- a/ncrf/_model.py
+++ b/ncrf/_model.py
@@ -131,20 +131,20 @@ def covariate_from_stim(
 ) -> list[FloatArray]:
     """Form lagged covariate matrices from one or more stimulus NDVars.
 
-    parameters
+    Parameters
     ----------
     stims
         Predictor variables. Each predictor must provide a ``time`` axis and may have
         at most one additional feature dimension before time.
     Ms
         Filter lengths, in samples, for each expanded predictor channel.
-    start
+    starts
         Start offsets, in samples, for each expanded predictor channel.
 
-    returns
+    Returns
     -------
-    x
-        Covariate matrices.
+    list
+        Covariate matrices, one per expanded predictor channel.
     """
     ws = []
     for stim in stims:
@@ -550,7 +550,7 @@ class NCRF:
     3. Initialize :class:`NCRF` instance with desired properties
     4. Call :meth:`NCRF.fit` with the :class:`RegressionData` instance to
        estimate the cortical TRFs.
-    5. Access the cortical TRFs in :attr:`NCRF.h`.
+    5. Access the cortical TRFs in the ``NCRF.h`` attribute.
     """
     _name = 'cTRFs estimator'
     _cv_results = None
@@ -995,7 +995,7 @@ class NCRF:
         """Build the smooth objective and gradient passed to FASTA.
 
         Parameters
-        ---------
+        ----------
         data
             Prepared regression data.
         """
@@ -1046,15 +1046,15 @@ class NCRF:
         """Evaluate the current objective value on a dataset.
 
         Parameters
-        ---------
+        ----------
         data
             Dataset on which to evaluate the objective.
 
         Returns
         -------
-        float or tuple of float
-            Objective value, or a tuple with the weighted L2 term when
-            ``return_wl2`` is true.
+        float | tuple[float, float]
+            Objective value, or a pair containing the objective value and the
+            weighted L2 term when ``return_wl2`` is true.
         """
         ll2 = 0
         logdet = 0
@@ -1265,7 +1265,7 @@ class NCRF:
         ----------
         data
             Dataset object compatible with model fitting and exposing
-            :meth:`timeslice` for train/test partitioning.
+            :meth:`ncrf.RegressionData.timeslice` for train/test partitioning.
         n_splits
             number of folds for cross-validation, If None, it will use values
             specified in config.py.

--- a/ncrf/_ncrf.py
+++ b/ncrf/_ncrf.py
@@ -122,7 +122,7 @@ def fit_ncrf(
         specifies one stop time per predictor.
     nlevels
         Decides the density of Gabor atoms. Bigger nlevel -> less dense basis.
-        By default it is set to `1`. `nlevesl > 2` should be used with caution.
+        By default it is set to ``1``. ``nlevel > 2`` should be used with caution.
     n_iter
         Number of outer iterations of the algorithm, by default set to 10.
     n_iterc

--- a/ncrf/_ncrf.py
+++ b/ncrf/_ncrf.py
@@ -173,7 +173,7 @@ def fit_ncrf(
     MEG data ``y`` with dimensions (case, sensor, time) and predictor ``x``
     with dimensions (case, time)::
 
-        ncrf(y, x, fwd, cov)
+        fit_ncrf(y, x, fwd, cov)
 
     ``x`` can always also have an additional predictor dimension, for example,
     if ``x`` represents a spectrogram: (case, frequency, time). The case
@@ -185,16 +185,16 @@ def fit_ncrf(
     modeling simultaneous responses to an attended and an unattended stimulus
     with ``x_attended`` and ``x_unattended``::
 
-        ncrf(y, [x_attended, x_unattended], fwd, cov)
+        fit_ncrf(y, [x_attended, x_unattended], fwd, cov)
 
     Multiple data segments can also be specified as list. E.g., if ``y1`` and
     ``y2`` are responses to stimuli ``x1`` and ``x2``, respoectively::
 
-        ncrf([y1, y2], [x1, x2], fwd, cov)
+        fit_ncrf([y1, y2], [x1, x2], fwd, cov)
 
     And with multiple predictors::
 
-        ncrf([y1, y2], [[x1_attended, x1_unattended], [x2_attended, x2_unattended]], fwd, cov)
+        fit_ncrf([y1, y2], [[x1_attended, x1_unattended], [x2_attended, x2_unattended]], fwd, cov)
 
     References
     ----------

--- a/ncrf/_ncrf.py
+++ b/ncrf/_ncrf.py
@@ -101,7 +101,8 @@ def fit_ncrf(
         Observed data. A single contiguous segment can be passed as an
         :class:`eelbrain.NDVar` with ``sensor`` and ``time`` dimensions, equal-length
         trials can be packed into an NDVar with a ``case`` dimension, and unequal-length
-        segments can be supplied as a sequence (e.g., :class:`list` of :class:`NDVar`).
+        segments can be supplied as a sequence (e.g., :class:`list` of
+        :class:`eelbrain.NDVar`).
     stim
         One or more predictors corresponding to each item in ``meg``. Predictors can
         be supplied as one NDVar per segment or as nested sequences when each segment
@@ -165,8 +166,7 @@ def fit_ncrf(
 
     Returns
     -------
-    trf
-        The result of the model fit.
+    The fitted :class:`ncrf._model.NCRF` instance.
 
     Examples
     --------

--- a/ncrf/_ncrf.py
+++ b/ncrf/_ncrf.py
@@ -2,8 +2,7 @@
 
 This module is the public entrypoint for the library. It normalizes the
 different supported input layouts, derives stimulus scaling metadata, prepares
-:class:`ncrf._model.RegressionData`, and then delegates optimization to
-:class:`ncrf._model.NCRF`.
+:class:`RegressionData`, and then delegates optimization to :class:`NCRF`.
 """
 # Authors: Proloy Das <email:proloyd94@gmail.com>
 #          Christian Brodbeck <email:brodbecc@mcmaster.ca>
@@ -166,7 +165,7 @@ def fit_ncrf(
 
     Returns
     -------
-    :class:`ncrf.NCRF`
+    :class:`NCRF`
         Fitted model instance.
 
     Examples

--- a/ncrf/_ncrf.py
+++ b/ncrf/_ncrf.py
@@ -1,23 +1,41 @@
+"""High-level orchestration for preparing inputs and fitting an NCRF model.
+
+This module is the public entrypoint for the library. It normalizes the
+different supported input layouts, derives stimulus scaling metadata, prepares
+:class:`ncrf._model.RegressionData`, and then delegates optimization to
+:class:`ncrf._model.NCRF`.
+"""
 # Authors: Proloy Das <email:proloyd94@gmail.com>
 #          Christian Brodbeck <email:brodbecc@mcmaster.ca>
 #          Marlies Gillis <email: >
 # License: BSD (3-clause)
-from typing import List
+from __future__ import annotations
+
 import collections
+from collections.abc import Sequence
+from typing import TypeAlias
 
 from eelbrain import NDVar, Sensor
-from mne import Covariance
+import mne
 import numpy as np
 
 from ._model import NCRF, RegressionData
 
 
 DEFAULT_MUs = np.logspace(-3, -1, 7)
+NormalizationValue: TypeAlias = NDVar | float
+StimulusInput: TypeAlias = NDVar | Sequence[NDVar]
+TrialStimulusInput: TypeAlias = StimulusInput | Sequence[StimulusInput]
+MegInput: TypeAlias = NDVar | Sequence[NDVar]
+MuInput: TypeAlias = float | Sequence[float] | str
 
 
-def _handle_noise_channels(noise: Covariance | NDVar | np.ndarray, sensor_dim: Sensor) -> np.ndarray:
-
-    if isinstance(noise, Covariance):
+def _handle_noise_channels(
+        noise: mne.Covariance | NDVar | np.ndarray,
+        sensor_dim: Sensor,
+) -> np.ndarray:
+    """Return the noise covariance aligned to the MEG sensor order."""
+    if isinstance(noise, mne.Covariance):
         chs_noise = set(noise.ch_names)
         chs_data = set(sensor_dim.names)
         missing = sorted(chs_data - chs_noise)
@@ -45,15 +63,33 @@ def _handle_noise_channels(noise: Covariance | NDVar | np.ndarray, sensor_dim: S
         noise_cov = noise
 
     else:
-        raise TypeError(f"Invalid noise type: {type(noise)}. Must be NDVar, Covariance, or ndarray.")
+        raise TypeError(f"Invalid noise type: {type(noise)}. Must be NDVar, mne.Covariance, or ndarray.")
 
     return noise_cov
 
 
-def fit_ncrf(meg, stim, lead_field, noise, tstart=0, tstop=0.5, nlevels=1,
-             n_iter=10, n_iterc=10, n_iterf=100, normalize=False, in_place=False,
-             mu='auto', tol=1e-3, verbose=False, n_splits=3, n_workers=None,
-             use_ES=False, gaussian_fwhm=20.0, do_post_normalization=True):
+def fit_ncrf(
+        meg: MegInput,
+        stim: TrialStimulusInput,
+        lead_field: NDVar,
+        noise: mne.Covariance | NDVar | np.ndarray,
+        tstart: float | Sequence[float] = 0,
+        tstop: float | Sequence[float] = 0.5,
+        nlevels: int = 1,
+        n_iter: int = 10,
+        n_iterc: int = 10,
+        n_iterf: int = 100,
+        normalize: bool | str = False,
+        in_place: bool = False,
+        mu: MuInput = 'auto',
+        tol: float = 1e-3,
+        verbose: bool = False,
+        n_splits: int = 3,
+        n_workers: int | None = None,
+        use_ES: bool = False,
+        gaussian_fwhm: float = 20.0,
+        do_post_normalization: bool = True,
+) -> NCRF:
     r"""One shot function for cortical TRF localization.
 
     Estimate both TRFs and source variance from the observed MEG data by solving
@@ -61,73 +97,75 @@ def fit_ncrf(meg, stim, lead_field, noise, tstart=0, tstop=0.5, nlevels=1,
 
     Parameters
     ----------
-    meg :  NDVar ([case,] sensor, time) | list[NDVar]
-        If multiple trials are the same length they can be specified as
-        :class:`eelbrain.NDVar` with case dimension, if they are different length they
-        can be supplied as list.
-    stim : eelbrain.NDVar ([case, dim,] time) | list[NDVar]
-        One or multiple predictors corresponding to each item in ``meg``.
-    lead_field : NDVar
-        forward solution a.k.a. lead field matrix.
-    noise : mne.Covariance | NDVar | np.ndarray
-        The empty room noise covariance as :class:`mne.Covariance`, or data
-        from which to compute it as :class:`eelbrain.NDVar` or
-        :class:`numpy.ndarray`. If supplied as a covariance matrix, the sensors
-        are cross-checked to ensure all the sensors in ``meg`` are also present
-        in covaraince matrix, else the check is skipped. Raises error if
-        any sensor is missing in noise covaraince, or in case of shape
-        mismatch.
-    tstart : float | list[float]
-        Start of the TRF in seconds. Can define multiple tstarts for more than 1 predictor.
-    tstop : float | list[float]
-        Stop of the TRF in seconds. Can define multiple tstops for more than 1 predictor.
-    nlevels : int
+    meg
+        Observed data. A single contiguous segment can be passed as an
+        :class:`eelbrain.NDVar` with ``sensor`` and ``time`` dimensions, equal-length
+        trials can be packed into an NDVar with a ``case`` dimension, and unequal-length
+        segments can be supplied as a sequence (e.g., :class:`list` of :class:`NDVar`).
+    stim
+        One or more predictors corresponding to each item in ``meg``. Predictors can
+        be supplied as one NDVar per segment or as nested sequences when each segment
+        has multiple predictors. Individual predictors may have only a ``time`` axis or
+        one additional feature dimension before ``time``.
+    lead_field
+        Forward solution a.k.a. lead-field matrix.
+    noise
+        Empty-room noise covariance, either directly as :class:`mne.Covariance`, as an
+        :class:`eelbrain.NDVar` from which a covariance will be estimated, or as an
+        already aligned covariance matrix. Covariance inputs are checked against the MEG
+        sensor order and raise an error when sensors are missing or the shape is wrong.
+    tstart
+        Start of the TRF in seconds. A scalar applies to all predictors; a sequence
+        specifies one start time per predictor.
+    tstop
+        Stop of the TRF in seconds. A scalar applies to all predictors; a sequence
+        specifies one stop time per predictor.
+    nlevels
         Decides the density of Gabor atoms. Bigger nlevel -> less dense basis.
         By default it is set to `1`. `nlevesl > 2` should be used with caution.
-    n_iter : int
-        Number of out iterations of the algorithm, by default set to 10.
-    n_iterc : int
+    n_iter
+        Number of outer iterations of the algorithm, by default set to 10.
+    n_iterc
         Number of Champagne iterations within each outer iteration, by default set to 10.
-    n_iterf : int
+    n_iterf
         Number of FASTA iterations within each outer iteration, by default set to 100.
-    normalize : bool | 'l2' | 'l1'
+    normalize
         Scale ``stim`` before model fitting: subtract the mean and divide by
-        the standard deviation (when ``nomrmalize='l2'`` or ``normalize=True``)
+        the standard deviation (when ``normalize='l2'`` or ``normalize=True``)
         or the mean absolute value (when ``normalize='l1'``). By default,
         ``normalize=False`` leaves ``stim`` data untouched.
-    in_place: bool
+    in_place
         With ``in_place=False`` (default) the original ``meg`` and ``stims`` are left untouched;
         use ``in_place=True`` to save memory by using the original ``meg`` and ``stim``.
-    mu : 'auto' | float | sequence[float]
-        Choice of regularizer parameters. Specify a single value to fit a model
-        corresponding to that value. Alternatively, specify a range over which
-        cross-validation will be done. By default (``mu='auto'``) a range of
-        values for cross-validation is chosen based on the data.
-    tol : float
+    mu
+        Choice of regularizer parameters. Pass a single value to fit one model, a
+        sequence to cross-validate over an explicit grid, or ``'auto'`` to derive a
+        search range from the data.
+    tol
         Tolerance factor deciding stopping criterion for the overall algorithm. The iterations
         are stooped when ``norm(trf_new - trf_old)/norm(trf_old) < tol`` condition is met.
         By default ``tol=1e-3``.
-    verbose : bool
+    verbose
         If True prints intermediate results, by default False.
-    n_splits : int
+    n_splits
         Number of cross-validation folds. By default it uses 3-fold cross-validation.
-    n_workers : int (optional)
+    n_workers
         Number of workers to spawn for cross-validation. If None, it will use ``cpu_count/2``.
-    use_ES : bool (optional)
+    use_ES
         Use estimation stability criterion :cite:`limEstimationStabilityCrossValidation2016` to
         choose the best ``mu``. (False, by default)
-    gaussian_fwhm : float (optional)
+    gaussian_fwhm
         Specifies the full width half maximum (fwmh) for the Gaussian kernel (used as elements of
         the time basis), the default is 20 ms. The standard deviation (std) is related to the
         fwmh as following:
         :math:`std = fwhm / (2 * (sqrt(2 * log(2))))`.
-    do_post_normalization : bool (optional)
+    do_post_normalization
         Scales covariate matrices of different predictor variables by spectral norms to
         equalize their spectral spread (=1). (True, by default)
 
     Returns
     -------
-    trf : NCRF
+    trf
         The result of the model fit.
 
     Examples
@@ -165,7 +203,7 @@ def fit_ncrf(meg, stim, lead_field, noise, tstart=0, tstop=0.5, nlevels=1,
     """
     # data copy?
     if not isinstance(in_place, bool):
-        raise TypeError(f"in_place={in_place!r}, need bool")
+        raise TypeError(f"{in_place=}, need bool")
 
     # make meg/stim representation uniform:
     meg_trials = []  # [trial_1, trial_2, ...]
@@ -175,7 +213,7 @@ def fit_ncrf(meg, stim, lead_field, noise, tstart=0, tstop=0.5, nlevels=1,
         stim_list = [stim]
     elif isinstance(meg, collections.abc.Sequence):
         if len(stim) != len(meg):
-            raise ValueError(f"meg={meg}, stim={stim}: different length")
+            raise ValueError(f"{meg=}, {stim=}: different length")
         meg_list = list(meg)
         stim_list = list(stim)
     else:
@@ -192,18 +230,18 @@ def fit_ncrf(meg, stim, lead_field, noise, tstart=0, tstop=0.5, nlevels=1,
         if stim_is_single is None:
             stim_is_single = isinstance(stim_chunk, NDVar)
         elif stim_is_single != isinstance(stim_chunk, NDVar):
-            raise ValueError(f"stim={stim}: inconsistent element types (NDVar/list)")
+            raise ValueError(f"{stim=}: inconsistent element types (NDVar/list)")
 
         if stim_is_single:
             stim_chunk = [stim_chunk]
 
         if n_trials:
             if not all(s.has_case and len(s) == n_trials for s in stim_chunk):
-                raise ValueError(f"meg={meg}, stim={stim}: inconsistent number of cases")
+                raise ValueError(f"{meg=}, {stim=}: inconsistent number of cases")
             stim_trials.extend(zip(*stim_chunk))
         else:
             if any(s.has_case for s in stim_chunk):
-                raise ValueError(f"meg={meg}, stim={stim}: inconsistent case dimensions")
+                raise ValueError(f"{meg=}, {stim=}: inconsistent case dimensions")
             stim_trials.append(stim_chunk)
 
     # normalize=True defaults to 'l2'
@@ -214,10 +252,10 @@ def fit_ncrf(meg, stim, lead_field, noise, tstart=0, tstop=0.5, nlevels=1,
         s_baseline, s_scale = get_scaling(stim_trials, normalize)
     elif isinstance(normalize, str):
         if normalize not in ('l1', 'l2'):
-            raise ValueError(f"normalize={normalize!r}, need bool or 'l1' or 'l2'")
+            raise ValueError(f"{normalize=}, need bool or 'l1' or 'l2'")
         s_baseline, s_scale = get_scaling(stim_trials, normalize)
     else:
-        raise TypeError(f"normalize={normalize!r}, need bool or str")
+        raise TypeError(f"{normalize=}, need bool or str")
 
     # Call `REG_Data.add_data` once for each contiguous segment of MEG data
     ds = RegressionData(tstart, tstop, nlevels, s_baseline, s_scale, stim_is_single, gaussian_fwhm)
@@ -226,13 +264,10 @@ def fit_ncrf(meg, stim, lead_field, noise, tstart=0, tstop=0.5, nlevels=1,
             ss = [s.copy() for s in ss]
         ds.add_data(r, ss)
 
-    # import ipdb; ipdb.set_trace()
     if do_post_normalization:
         ds.post_normalization()
-    # import ipdb; ipdb.set_trace()
 
     # noise covariance
-
     noise_cov = _handle_noise_channels(noise, ds.sensor_dim)
 
     # Regularizer Choice
@@ -250,8 +285,7 @@ def fit_ncrf(meg, stim, lead_field, noise, tstart=0, tstop=0.5, nlevels=1,
         mus = 'auto'
         do_crossvalidation = True
     else:
-        raise ValueError(f"invalid mu={mu!r}, supports tuple, list, np.ndarray or scalar float"
-                         f"optionally, may be left 'auto' if not sure!")
+        raise ValueError(f"invalid {mu=}, supports tuple, list, np.ndarray or scalar float optionally, may be left 'auto' if not sure")
 
     if lead_field.get_dim('sensor') != ds.sensor_dim:
         lead_field = lead_field.sub(sensor=ds.sensor_dim)
@@ -262,7 +296,11 @@ def fit_ncrf(meg, stim, lead_field, noise, tstart=0, tstop=0.5, nlevels=1,
     return model
 
 
-def get_scaling(all_stims: List[List[NDVar]], normalize: str):
+def get_scaling(
+        all_stims: list[list[NDVar]],
+        normalize: str,
+) -> tuple[list[NormalizationValue], list[NormalizationValue]]:
+    """Compute per-predictor centering and scaling values for stimulus normalization."""
     stim_trials = [trials for trials in zip(*all_stims)]  # -> [[stim_1_trial_1, stim_1_trial_2, ...], ...]
     n = sum(len(stim.time) for stim in stim_trials[0])
     means = [sum(s.sum('time') for s in trials) / n for trials in stim_trials]

--- a/ncrf/_ncrf.py
+++ b/ncrf/_ncrf.py
@@ -166,7 +166,7 @@ def fit_ncrf(
 
     Returns
     -------
-    The fitted :class:`ncrf._model.NCRF` instance.
+    The fitted :class:`NCRF` instance.
 
     Examples
     --------

--- a/ncrf/_ncrf.py
+++ b/ncrf/_ncrf.py
@@ -166,7 +166,8 @@ def fit_ncrf(
 
     Returns
     -------
-    The fitted :class:`NCRF` instance.
+    :class:`ncrf.NCRF`
+        Fitted model instance.
 
     Examples
     --------

--- a/ncrf/_ncrf.py
+++ b/ncrf/_ncrf.py
@@ -196,6 +196,11 @@ def fit_ncrf(
 
         fit_ncrf([y1, y2], [[x1_attended, x1_unattended], [x2_attended, x2_unattended]], fwd, cov)
 
+    For complete workflows, see the gallery examples
+    :ref:`Volume Source Example <sphx_glr_auto_examples_00_example-vol-src.py>`
+    and
+    :ref:`Surface source Example <sphx_glr_auto_examples_01_example-surf-src.py>`.
+
     References
     ----------
     .. bibliography::

--- a/ncrf/dsyevh3C/__init__.py
+++ b/ncrf/dsyevh3C/__init__.py
@@ -1,1 +1,3 @@
-from .dsyevh3py import eig3, compute_gamma_c
+"""Bridge to small C/Cython kernels used by the NCRF solver hot paths."""
+
+from .dsyevh3py import compute_gamma_c, eig3

--- a/ncrf/dsyevh3C/dsyevh3py.pyx
+++ b/ncrf/dsyevh3C/dsyevh3py.pyx
@@ -1,3 +1,7 @@
+# cython: boundscheck=False, wraparound=False
+# cython: profile=False
+# distutils: language = c++
+# Author: Proloy Das <proloy@umd.edu>
 """Cython bridge for 3x3 eigendecomposition and Gamma updates in NCRF.
 
 This module keeps the small dense linear-algebra kernels used inside the
@@ -25,11 +29,6 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301
 USA
 """
 
-# cython: boundscheck=False, wraparound=False
-# cython: profile=False
-# distutils: language = c++
-# optimized functions
-# Author: Proloy Das <proloy@umd.edu>
 cimport cython
 cimport numpy as cnp
 from libc.math cimport sqrt

--- a/ncrf/dsyevh3C/dsyevh3py.pyx
+++ b/ncrf/dsyevh3C/dsyevh3py.pyx
@@ -132,7 +132,7 @@ def compute_gamma_c(FLOAT64[:, :] zpy, FLOAT64[:, :] xpy, FLOAT64[:, :] gamma):
                    = V(E)**(-1/2)V' * ( V (UDU') V')** (1/2) * V(E)**(-1/2)V'
                    = V (E)**(-1/2) U (D)**(1/2) U' (E)**(-1/2) V'
 
-    parameters
+    Parameters
     ----------
     z: ndarray
         array of shape (dc, dc)
@@ -142,7 +142,7 @@ def compute_gamma_c(FLOAT64[:, :] zpy, FLOAT64[:, :] xpy, FLOAT64[:, :] gamma):
         array of shape (dc, dc)
         auxiliary variable, x_i
 
-    returns
+    Returns
     -------
     ndarray
     array of shape (dc, dc)

--- a/ncrf/dsyevh3C/dsyevh3py.pyx
+++ b/ncrf/dsyevh3C/dsyevh3py.pyx
@@ -1,15 +1,11 @@
-# cython: boundscheck=False, wraparound=False
-# cython: profile=False
-# distutils: language = c++
-# optimized functions
-# Author: Proloy Das <proloy@umd.edu>
-""" optimized functions for group-prox calculation and 3x3 eigval decomposition
+"""Cython bridge for 3x3 eigendecomposition and Gamma updates in NCRF.
 
+This module keeps the small dense linear-algebra kernels used inside the
+Champagne updates close to compiled code so the Python solver can stay focused
+on orchestration.
 
 Contains code from 'Efficient numerical diagonalization of hermitian 3x3 matrices'
 governed by following license ( GNU LESSER GENERAL PUBLIC LICENSE Version 2.1)
-
-
 Copyright (C) 2008 Joachim Kopp
 All rights reserved.
 
@@ -28,6 +24,12 @@ License along with this library; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301
 USA
 """
+
+# cython: boundscheck=False, wraparound=False
+# cython: profile=False
+# distutils: language = c++
+# optimized functions
+# Author: Proloy Das <proloy@umd.edu>
 cimport cython
 cimport numpy as cnp
 from libc.math cimport sqrt

--- a/ncrf/opt.pyx
+++ b/ncrf/opt.pyx
@@ -1,5 +1,7 @@
+"""Cython kernels for the group-sparsity proximal operator used by NCRF."""
+
 # Author: Proloy Das <proloy@umd.edu>
-# License: BSD (3-clause) 
+# License: BSD (3-clause)
 
 #cython: boundscheck=False, wraparound=False
 # cython: profile=False

--- a/ncrf/tests/__init__.py
+++ b/ncrf/tests/__init__.py
@@ -1,3 +1,5 @@
+"""Regression tests and test-data helpers for the NCRF package."""
+
 # Author: Proloy Das <email:proloyd94@gmail.com>
 # License: BSD (3-clause)
 from .fetch import fetch_dataset

--- a/ncrf/tests/fetch.py
+++ b/ncrf/tests/fetch.py
@@ -1,3 +1,5 @@
+"""Test-data download and loading helpers for the NCRF regression suite."""
+
 # Author: Proloy Das <email:proloyd94@gmail.com>
 # License: BSD (3-clause)
 import os
@@ -9,6 +11,7 @@ import logging
 
 from pathlib import Path
 from shutil import rmtree
+from typing import Any
 
 
 logger = logging.getLogger(__name__)
@@ -28,7 +31,8 @@ folder_name = "ncrf-testing-data"
 _NAMES = ('meg', 'stim', 'fwd_sol', 'emptyroom')
 
 
-def fetch_dataset(force_download=False):
+def fetch_dataset(force_download: bool = False) -> Path:
+    """Ensure the versioned test dataset is available locally and return its path."""
     # manage local storage
     root_dir = Path(os.path.realpath(os.path.join(__file__, '..', '..', '..')))
     final_path = root_dir / folder_name
@@ -96,7 +100,8 @@ def fetch_dataset(force_download=False):
     return final_path
 
 
-def load(name):
+def load(name: str) -> Any:
+    """Load one of the packaged regression-test fixtures by name."""
     folder_name = fetch_dataset()
     if name in _NAMES:
         fname = os.path.join(folder_name, f"{name}.pickled")

--- a/ncrf/tests/test_model.py
+++ b/ncrf/tests/test_model.py
@@ -1,3 +1,5 @@
+"""Tests for low-level stimulus-to-covariate preparation in the NCRF stack."""
+
 # Author: Proloy Das <email:proloyd94@gmail.com>
 # License: BSD (3-clause)
 import numpy as np

--- a/ncrf/tests/test_ncrf.py
+++ b/ncrf/tests/test_ncrf.py
@@ -1,3 +1,5 @@
+"""End-to-end tests for the public ``fit_ncrf()`` workflow and model outputs."""
+
 # Author: Proloy Das <email:proloyd94@gmail.com>
 # License: BSD (3-clause)
 import pickle

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,6 @@ classifiers = [
   'Programming Language :: Python :: 3.11',
   'Programming Language :: Python :: 3.12',
   'Programming Language :: Python :: 3.13',
-  'Programming Language :: Python :: 3.9',
 ]
 dependencies = [
   'numpy>=1.23,<3',
@@ -40,7 +39,7 @@ maintainers = [
 ]
 name = 'ncrf'
 readme = 'README.md'
-requires-python = '>=3.9'
+requires-python = '>=3.10'
 version = '0.4.0.dev0'
 
 [project.optional-dependencies]


### PR DESCRIPTION
A first step at modernizing the code base. This just adds docstrings and type hints without any change in functionality (using Codex and some hand corrections). I had to update the doc build to enable cross-references to the object based API.

Only change is I removed `gaussian_basis` import in `ncrf`. It does not seem like a function users would need.

 @proloyd any thoughts?