### PR TITLE
TEST time shift/lag equivalence (xfail)

### DIFF
--- a/ncrf/tests/test_ncrf.py
+++ b/ncrf/tests/test_ncrf.py
@@ -95,18 +95,39 @@ def test_ncrf_shifted_nonzero_lags():
     fwd = load('fwd_sol')
     emptyroom = load('emptyroom')
 
-    # Get a short excerpt from the test data
+    # Use a short interior excerpt so the shifted windows below can extend by
+    # ``shift`` without running past the available test data.
     tstep = meg.get_dim('time').tstep
     segment_start = 20 * tstep
-    segment_stop = segment_start + 80 * tstep
+    shift = 5 * tstep
+    lag_stop = 10 * tstep
+    segment_stop = segment_start + 75 * tstep
+
+    # Baseline fit: predictor and MEG share the same 75-sample window, and the
+    # model estimates lags from 0 to ``lag_stop``.
     stim_segment = set_tmin(stim.sub(time=(segment_start, segment_stop)), 0)
     meg_0 = set_time(set_tmin(meg, -segment_start), stim_segment)
 
-    # Create meg data arrays with a shift relative to the predictor
-    shift = 5 * tstep
-    lag_stop = 10 * tstep
-    meg_positive = set_time(set_tmin(meg, shift - segment_start), stim_segment)
-    meg_negative = set_time(set_tmin(meg, -shift - segment_start), stim_segment)
+    # Positive lag fit: include ``shift`` extra predictor samples at the end.
+    # After dropping the first ``shift`` invalid design rows, this uses the same
+    # predictor and MEG samples as the baseline fit.
+    stim_positive = set_tmin(stim.sub(time=(segment_start, segment_stop + shift)), 0)
+    meg_positive = set_time(set_tmin(meg, shift - segment_start), stim_positive)
+
+    # Negative lag fit: include ``shift`` extra predictor samples at the start.
+    # After dropping the last ``shift`` invalid design rows, this again uses the
+    # same predictor and MEG samples as the baseline fit.
+    stim_negative = set_tmin(stim.sub(time=(segment_start - shift, segment_stop)), 0)
+    meg_negative = set_time(set_tmin(meg, -segment_start), stim_negative)
+
+    # Guard the test setup itself: all three fits should differ only in the
+    # time labels/lag windows, not in the effective numeric samples.
+    lag_samples = int(round(lag_stop / tstep))
+    shift_samples = int(round(shift / tstep))
+    np.testing.assert_array_equal(stim_positive.x[:-shift_samples], stim_segment.x)
+    np.testing.assert_array_equal(stim_negative.x[shift_samples:], stim_segment.x)
+    np.testing.assert_array_equal(meg_positive.x[:, lag_samples + shift_samples:], meg_0.x[:, lag_samples:])
+    np.testing.assert_array_equal(meg_negative.x[:, lag_samples:-shift_samples], meg_0.x[:, lag_samples:])
 
     fit_kwargs = dict(
         mu=0.001,
@@ -121,11 +142,11 @@ def test_ncrf_shifted_nonzero_lags():
         meg_0, stim_segment, fwd, emptyroom, tstart=0, tstop=lag_stop, **fit_kwargs,
     )
     model_positive = fit_ncrf(
-        meg_positive, stim_segment, fwd, emptyroom, tstart=shift,
+        meg_positive, stim_positive, fwd, emptyroom, tstart=shift,
         tstop=lag_stop + shift, **fit_kwargs,
     )
     model_negative = fit_ncrf(
-        meg_negative, stim_segment, fwd, emptyroom, tstart=-shift,
+        meg_negative, stim_negative, fwd, emptyroom, tstart=-shift,
         tstop=lag_stop - shift, **fit_kwargs,
     )
 

--- a/ncrf/tests/test_ncrf.py
+++ b/ncrf/tests/test_ncrf.py
@@ -3,7 +3,10 @@
 # Author: Proloy Das <email:proloyd94@gmail.com>
 # License: BSD (3-clause)
 import pickle
+
+from eelbrain import set_time, set_tmin
 import numpy as np
+import pytest
 
 from ncrf import fit_ncrf
 from ncrf.tests.fetch import load
@@ -80,3 +83,54 @@ def test_ncrf():
     # test without multiprocessing
     model_no_mp = fit_ncrf(meg, stim, fwd, emptyroom, tstop=0.2, normalize='l1', mu='auto', n_iter=1, n_iterc=2, n_iterf=2, n_workers=0, do_post_normalization=False)
     assert_dataobj_equal(model_no_mp.h, model.h)
+
+
+@pytest.mark.xfail(
+    reason="fit_ncrf currently includes padded edge rows for shifted non-zero lags",
+    strict=True,
+)
+def test_ncrf_shifted_nonzero_lags():
+    meg = load('meg').sub(case=0)
+    stim = load('stim').sub(case=0)
+    fwd = load('fwd_sol')
+    emptyroom = load('emptyroom')
+
+    # Get a short excerpt from the test data
+    tstep = meg.get_dim('time').tstep
+    segment_start = 20 * tstep
+    segment_stop = segment_start + 80 * tstep
+    stim_segment = set_tmin(stim.sub(time=(segment_start, segment_stop)), 0)
+    meg_0 = set_time(set_tmin(meg, -segment_start), stim_segment)
+
+    # Create meg data arrays with a shift relative to the predictor
+    shift = 5 * tstep
+    lag_stop = 10 * tstep
+    meg_positive = set_time(set_tmin(meg, shift - segment_start), stim_segment)
+    meg_negative = set_time(set_tmin(meg, -shift - segment_start), stim_segment)
+
+    fit_kwargs = dict(
+        mu=0.001,
+        tol=0,
+        verbose=False,
+        n_iter=1,
+        n_iterc=1,
+        n_iterf=5,
+        do_post_normalization=False,
+    )
+    model_0 = fit_ncrf(
+        meg_0, stim_segment, fwd, emptyroom, tstart=0, tstop=lag_stop, **fit_kwargs,
+    )
+    model_positive = fit_ncrf(
+        meg_positive, stim_segment, fwd, emptyroom, tstart=shift,
+        tstop=lag_stop + shift, **fit_kwargs,
+    )
+    model_negative = fit_ncrf(
+        meg_negative, stim_segment, fwd, emptyroom, tstart=-shift,
+        tstop=lag_stop - shift, **fit_kwargs,
+    )
+
+    assert np.linalg.norm(model_0.theta) > 0
+    for model_shifted in (model_positive, model_negative):
+        np.testing.assert_allclose(model_shifted.theta, model_0.theta)
+        np.testing.assert_allclose(model_shifted.residual, model_0.residual)
+        np.testing.assert_allclose(model_shifted.explained_var, model_0.explained_var)


### PR DESCRIPTION
I came across this while working on refactoring `RegressionData`. Wouldn't we expect the test that I added to pass? I.e., wouldn't we expect that if we shift the data and use correspondingly adjusted lags, the result should be the same?