### PR TITLE
Refactor `RegressionData`

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -41,7 +41,13 @@ exclude_patterns = ["_build", "Thumbs.db", ".DS_Store", "**.ipynb_checkpoints"]
 
 # Sphinx will warn about all references where the target cannot be found.
 nitpicky = True
-nitpick_ignore = [("py:obj", "optional"), ("py:obj", "NCRF")]
+nitpick_ignore = [
+    ("py:obj", "optional"),
+    ("py:obj", "NCRF"),
+    # NumPy's intersphinx inventory resolves ndarray/dtype, but not this scalar
+    # class when Sphinx expands npt.NDArray[np.float64] in dataclass signatures.
+    ("py:class", "numpy.float64"),
+]
 
 # A list of ignored prefixes for module index sorting.
 modindex_common_prefix = [f"{package}."]
@@ -76,7 +82,7 @@ napoleon_google_docstring = False
 napoleon_include_init_with_doc = True
 napoleon_include_special_with_doc = False
 napoleon_use_param = True
-napoleon_use_ivar = True
+napoleon_use_ivar = False
 napoleon_use_keyword = True
 napoleon_use_rtype = True
 

--- a/ncrf/_model.py
+++ b/ncrf/_model.py
@@ -333,7 +333,6 @@ class RegressionData:
             meg: list[FloatArray],
             covariates: list[FloatArray],
             norm_factor: float,
-            *,
             basis: list[FloatArray],
             filter_length: npt.NDArray[np.intp],
             tstart: list[float],
@@ -689,13 +688,12 @@ class NCRF:
     -----
     Usage:
 
-    1. Initialize :class:`RegressionData` instance with desired properties
-    2. Call :meth:`RegressionData.add_data` once for each contiguous
-       segment of MEG data
-    3. Initialize :class:`NCRF` instance with desired properties
-    4. Call :meth:`NCRF.fit` with the :class:`RegressionData` instance to
+    1. Use :meth:`RegressionData.from_data` to construct a prepared dataset
+       from MEG and stimulus segments.
+    2. Initialize :class:`NCRF` with the lead field and noise covariance.
+    3. Call :meth:`NCRF.fit` with the :class:`RegressionData` instance to
        estimate the cortical TRFs.
-    5. Access the cortical TRFs in the ``NCRF.h`` attribute.
+    4. Access the cortical TRFs in the ``NCRF.h`` attribute.
     """
     _name = 'cTRFs estimator'
     _cv_results = None

--- a/ncrf/_model.py
+++ b/ncrf/_model.py
@@ -262,31 +262,60 @@ def _compute_gamma_ip(z: FloatArray, x: FloatArray, gamma: FloatArray) -> None:
 class RegressionData:
     """Prepared regression dataset for NCRF fitting.
 
-    Parameters
-    ----------
-    tstart
-        Start of the TRF in seconds. A scalar applies to all predictors; a sequence
-        specifies one start time per predictor.
-    tstop
-        Stop of the TRF in seconds. A scalar applies to all predictors; a sequence
-        specifies one stop time per predictor.
-    nlevel
-        Decides the density of Gabor atoms. Bigger nlevel -> less dense basis.
-        By default, it is set to 1. ``nlevel > 2`` should be used with caution.
-    baseline
-        Per-predictor means to subtract from ``stim`` before covariate construction.
-    scaling
-        Per-predictor scaling factors applied after baseline subtraction.
-    stim_is_single
-        Records whether the original stimulus input was passed as a single predictor
-        per segment or as an explicit collection of predictors.
-    gaussian_fwhm
-        Full width at half maximum of the Gaussian basis functions, in milliseconds.
+    Use :meth:`from_data` to construct from raw MEG and stimulus NDVars.
     """
-    _n_predictor_variables = 1
 
     def __init__(
             self,
+            meg: list[FloatArray],
+            covariates: list[FloatArray],
+            norm_factor: float,
+            *,
+            basis: list[FloatArray],
+            filter_length,
+            tstart: list[float],
+            tstep: float,
+            tstop: list[float],
+            stim_is_single: bool,
+            stim_dims: list,
+            stim_names: list[str],
+            baseline,
+            scaling,
+            normalization: list,
+            gaussian_fwhm: float,
+            sensor_dim,
+            n_predictor_variables: int,
+            bbt: list[FloatArray] | None = None,
+            bE: list[FloatArray] | None = None,
+            EtE: list[FloatArray] | None = None,
+    ) -> None:
+        self.meg = meg
+        self.covariates = covariates
+        self._norm_factor = norm_factor
+        self.basis = basis
+        self.filter_length = filter_length
+        self.tstart = tstart
+        self.tstep = tstep
+        self.tstop = tstop
+        self._stim_is_single = stim_is_single
+        self._stim_dims = stim_dims
+        self._stim_names = stim_names
+        self.s_baseline = baseline
+        self.s_scaling = scaling
+        self.s_normalization = normalization
+        self.gaussian_fwhm = gaussian_fwhm
+        self.sensor_dim = sensor_dim
+        self._n_predictor_variables = n_predictor_variables
+        if bbt is not None:
+            self._bbt = bbt
+            self._bE = bE
+            self._EtE = EtE
+
+    @classmethod
+    def from_data(
+            cls,
+            meg: list[NDVar],
+            stim: list[Sequence[NDVar]],
             tstart: float | Sequence[float],
             tstop: float | Sequence[float],
             nlevel: int,
@@ -294,151 +323,174 @@ class RegressionData:
             scaling: Sequence[NDVar | float] | None,
             stim_is_single: bool,
             gaussian_fwhm: float = 20.0,
-    ) -> None:
-        self.tstart = tstart if isinstance(tstart, collections.abc.Sequence) else [tstart]
-        self.tstop = tstop if isinstance(tstop, collections.abc.Sequence) else [tstop]
-        self.nlevel = nlevel
-        self.s_baseline = baseline
-        self.s_scaling = scaling
-        self.s_normalization = []
-        self.meg: list[np.ndarray] = []  # (sensor, time)
-        self.covariates = []
-        self.tstep = None
-        self.filter_length = None
-        self.basis = None
-        self._norm_factor = None
-        self._stim_is_single = stim_is_single
-        self._stim_dims = None
-        self._stim_names = None
-        self.sensor_dim = None
-        self.gaussian_fwhm = gaussian_fwhm
-
-    def add_data(
-            self,
-            meg: NDVar,
-            stim: Sequence[NDVar] | NDVar,
             in_place: bool = False,
-    ) -> None:
-        """Add sensor measurements and predictor variables for one trial.
-
-        Call this method repeatedly to add data for multiple trials/recordings.
+            post_normalize: bool = True,
+    ) -> RegressionData:
+        """Construct a dataset from MEG and stimulus NDVars.
 
         Parameters
         ----------
         meg
-            MEG measurements for one contiguous segment, with ``sensor`` and ``time``
-            dimensions.
+            MEG segments, each an NDVar with ``sensor`` and ``time`` dimensions.
         stim
-            One or more predictor variables whose ``time`` axis matches ``meg``.
-            Each predictor can be one-dimensional over time or carry one feature
+            Stimulus lists, one per segment; each inner list contains one NDVar per
+            predictor. Each predictor may be 1-D over time or carry one feature
             dimension before time.
+        tstart
+            Start of the TRF in seconds. A scalar applies to all predictors; a
+            sequence specifies one start time per predictor.
+        tstop
+            Stop of the TRF in seconds. A scalar applies to all predictors; a
+            sequence specifies one stop time per predictor.
+        nlevel
+            Density of Gabor basis atoms. Bigger → less dense. ``nlevel > 2``
+            should be used with caution.
+        baseline
+            Per-predictor means to subtract from ``stim`` before covariate
+            construction.
+        scaling
+            Per-predictor scaling factors applied after baseline subtraction.
+        stim_is_single
+            Whether the original stimulus input was a single predictor per segment.
+        gaussian_fwhm
+            Full width at half maximum of the Gaussian basis functions, in ms.
         in_place
-            By default, ``meg`` and ``stim`` are copied to make them independent of the
-            objects supplied to the method. Set to ``True`` to skip the copy and
-            modify them in place, saving memory when working with large datasets.
+            If ``False`` (default), copies of ``stim`` are made before applying
+            baseline subtraction or scaling. Set to ``True`` to modify in place.
+        post_normalize
+            If ``True`` (default), equalize covariate scales across predictor
+            blocks by dividing each block by its average spectral norm.
         """
-        if self.sensor_dim is None:
-            self.sensor_dim = meg.get_dim('sensor')
-        elif meg.get_dim('sensor') != self.sensor_dim:
-            raise NotImplementedError('combining data segments with different sensors is not supported')
+        if not meg:
+            raise ValueError("meg is empty")
 
-        # check stim dimensions
-        meg_time: UTS = meg.get_dim('time')
-        stims = (stim,) if isinstance(stim, NDVar) else stim
-        stim_dims = []
-        for x in stims:
-            if x.get_dim('time') != meg_time:
-                raise ValueError(f"{stim=}: time axis incompatible with meg")
-            elif x.ndim == 1:
-                stim_dims.append(None)
-            elif x.ndim == 2:
-                dim, _ = x.get_dims((None, 'time'))
-                stim_dims.append(dim)
-            else:
-                raise ValueError(f"{stim=}: stimulus with more than 2 dimensions")
+        # Validate sensor consistency across segments
+        sensor_dim = meg[0].get_dim('sensor')
+        for m in meg[1:]:
+            if m.get_dim('sensor') != sensor_dim:
+                raise NotImplementedError('combining data segments with different sensors is not supported')
 
-        # Initialize TRF lag range
-        if len(self.tstart) == 1:
-            self.tstart = self.tstart * len(stim_dims)
-        if len(self.tstop) == 1:
-            self.tstop = self.tstop * len(stim_dims)
-        assert len(self.tstart) == len(stim_dims)
-        assert len(self.tstop) == len(stim_dims)
+        tstart = list(tstart) if isinstance(tstart, collections.abc.Sequence) else [tstart]
+        tstop = list(tstop) if isinstance(tstop, collections.abc.Sequence) else [tstop]
 
-        # stim normalization
-        if not in_place:
-            stims = [s.copy() for s in stims]
+        # State initialized from the first segment
+        stim_dims = None
+        stim_names = None
+        tstep = None
+        basis = None
+        filter_length = None
+        start_samples = None  # in-samples offsets, local to from_data
 
-        if self.s_baseline is not None:
-            if len(self.s_baseline) != len(stims):
-                raise ValueError(f"{stim=}: incompatible with baseline={self.s_baseline!r}")
-            for s, m in zip(stims, self.s_baseline):
-                s -= m
-        if self.s_scaling is not None:
-            if len(self.s_scaling) != len(stims):
-                raise ValueError(f"{stim=}: incompatible with scaling={self.s_scaling!r}")
-            for s, scale in zip(stims, self.s_scaling):
-                s /= scale
+        meg_arrays: list[FloatArray] = []
+        covariate_arrays: list[FloatArray] = []
+        s_normalization = []
+        norm_factor = None
+        n_predictor_variables = 1
 
-        if self.tstep is None:
-            # initialize time axis
-            self.tstep = meg_time.tstep
-            self.start = [int(round(tstart / self.tstep)) for tstart in self.tstart]
-            self.stop = [int(round(tstop / self.tstep)) for tstop in self.tstop]
-            self.filter_length = np.subtract(self.stop, self.start) + 1
-            # basis
-            self.basis = []
-            for tstart, tstop, filter_length in zip(self.tstart, self.tstop, self.filter_length):
-                x = np.linspace(int(round(1000 * tstart)), int(round(1000 * tstop)), filter_length)
-                self.basis.append(gaussian_basis(int(round((filter_length - 1) / self.nlevel)), x))
-            # stimuli
-            self._stim_dims = stim_dims
-            self._stim_names = [x.name for x in stims]
-        elif meg_time.tstep != self.tstep:
-            raise ValueError(f"{meg=}: incompatible time-step with previously added data")
-        else:
-            # check stimuli dimensions
-            if stim_dims != self._stim_dims:
-                raise ValueError(f"{stim=}: dimensions incompatible with previously added data")
+        for m, ss in zip(meg, stim):
+            ss = list(ss)
+            meg_time: UTS = m.get_dim('time')
 
-        # add meg data
-        m = max([basis.shape[0] for basis in self.basis])
-        y = meg.get_data(('sensor', 'time'))
-        # Drop MEG samples for which we don't have a complete stimulus history
-        y_ = y[:, m - 1:].astype(np.float64, copy=False)
-        if in_place or y_.base is None:
-            y = y_
-        else:
-            y = y_.copy()
-        # Check for flat channels
-        ch_var = np.var(y, axis=1)
-        zero_var = ch_var == 0
-        if zero_var.any():
-            flat_channels = self.sensor_dim.names[zero_var]
-            raise ValueError(f"{meg=}: data contains flat channels ({', '.join(flat_channels)})")
-        y /= sqrt(y.shape[1])  # Mind the normalization
-        self.meg.append(y)
+            # Determine stim feature dims for this segment
+            cur_stim_dims = []
+            for x in ss:
+                if x.get_dim('time') != meg_time:
+                    raise ValueError(f"stim={x!r}: time axis incompatible with meg")
+                elif x.ndim == 1:
+                    cur_stim_dims.append(None)
+                elif x.ndim == 2:
+                    dim, _ = x.get_dims((None, 'time'))
+                    cur_stim_dims.append(dim)
+                else:
+                    raise ValueError(f"stim={x!r}: more than 2 dimensions")
 
-        if self._norm_factor is None:
-            self._norm_factor = sqrt(y.shape[1])
+            if stim_dims is None:
+                # Initialize time/basis parameters from the first segment
+                stim_dims = cur_stim_dims
+                stim_names = [x.name for x in ss]
+                if len(tstart) == 1:
+                    tstart = tstart * len(stim_dims)
+                if len(tstop) == 1:
+                    tstop = tstop * len(stim_dims)
+                assert len(tstart) == len(stim_dims)
+                assert len(tstop) == len(stim_dims)
+                tstep = meg_time.tstep
+                start_samples = [int(round(ts / tstep)) for ts in tstart]
+                stop_samples = [int(round(te / tstep)) for te in tstop]
+                filter_length = np.subtract(stop_samples, start_samples) + 1
+                basis = []
+                for ts, te, fl in zip(tstart, tstop, filter_length):
+                    x = np.linspace(int(round(1000 * ts)), int(round(1000 * te)), fl)
+                    basis.append(gaussian_basis(int(round((fl - 1) / nlevel)), x))
+            elif meg_time.tstep != tstep:
+                raise ValueError(f"meg={m!r}: incompatible time-step with first segment")
+            elif cur_stim_dims != stim_dims:
+                raise ValueError(f"stim dimensions incompatible with first segment")
 
-        # add corresponding covariate matrix
-        stim_lens = [len(dim) if dim else 1 for dim in stim_dims]
-        filter_lengths = np.repeat(np.asanyarray(self.filter_length), stim_lens)
-        start = np.repeat(np.asanyarray(self.start), stim_lens)
-        _covariates = covariate_from_stim(stims, filter_lengths, start)
-        i = 0
-        covariates = []
-        for dim, basis in zip(stim_dims, self.basis):
-            l = len(dim) if dim else 1
-            covariates.extend([np.dot(x, basis) / sqrt(y.shape[1]) for x in _covariates[i:i + l]])
-            # Mind the normalization
-            i += l
-        self._n_predictor_variables = len(covariates)
-        self.s_normalization.append([linalg.norm(x, 2) for x in covariates])
+            # Apply stim normalization
+            if not in_place:
+                ss = [s.copy() for s in ss]
+            if baseline is not None:
+                if len(baseline) != len(ss):
+                    raise ValueError(f"baseline length {len(baseline)} != number of predictors {len(ss)}")
+                for s, b in zip(ss, baseline):
+                    s -= b
+            if scaling is not None:
+                if len(scaling) != len(ss):
+                    raise ValueError(f"scaling length {len(scaling)} != number of predictors {len(ss)}")
+                for s, sc in zip(ss, scaling):
+                    s /= sc
 
-        x = np.concatenate(covariates, axis=1).astype(np.float64)
-        self.covariates.append(x)
+            # Extract and normalize MEG array
+            m_max = max(b.shape[0] for b in basis)
+            y = m.get_data(('sensor', 'time'))
+            y_ = y[:, m_max - 1:].astype(np.float64, copy=False)
+            y = y_ if (in_place or y_.base is None) else y_.copy()
+            flat = np.var(y, axis=1) == 0
+            if flat.any():
+                raise ValueError(f"meg={m!r}: flat channels ({', '.join(sensor_dim.names[flat])})")
+            y /= sqrt(y.shape[1])
+            meg_arrays.append(y)
+            if norm_factor is None:
+                norm_factor = sqrt(y.shape[1])
+
+            # Build basis-projected covariate matrix
+            stim_lens = [len(d) if d else 1 for d in stim_dims]
+            fl_rep = np.repeat(np.asanyarray(filter_length), stim_lens)
+            st_rep = np.repeat(np.asanyarray(start_samples), stim_lens)
+            raw_covs = covariate_from_stim(ss, fl_rep, st_rep)
+            i = 0
+            covariates = []
+            for d, b in zip(stim_dims, basis):
+                l = len(d) if d else 1
+                covariates.extend([np.dot(x, b) / sqrt(y.shape[1]) for x in raw_covs[i:i + l]])
+                i += l
+            n_predictor_variables = len(covariates)
+            s_normalization.append([linalg.norm(x, 2) for x in covariates])
+            covariate_arrays.append(np.concatenate(covariates, axis=1).astype(np.float64))
+
+        # Equalize covariate scales across predictor blocks
+        if post_normalize:
+            n_vars = sum(len(d) if d else 1 for d in stim_dims)
+            if n_vars > 1:
+                stim_lens = [len(d) if d else 1 for d in stim_dims]
+                bl_lengths = np.repeat([b.shape[1] for b in basis], stim_lens)
+                avg_norm = np.asanyarray(s_normalization).mean(axis=0)
+                col = 0
+                for bl, norm in zip(bl_lengths, avg_norm):
+                    for cov in covariate_arrays:
+                        cov[:, col:col + bl] /= norm
+                    col += bl
+
+        return cls(
+            meg_arrays, covariate_arrays, norm_factor,
+            basis=basis, filter_length=filter_length,
+            tstart=tstart, tstep=tstep, tstop=tstop,
+            stim_is_single=stim_is_single, stim_dims=stim_dims,
+            stim_names=stim_names, baseline=baseline, scaling=scaling,
+            normalization=s_normalization, gaussian_fwhm=gaussian_fwhm,
+            sensor_dim=sensor_dim, n_predictor_variables=n_predictor_variables,
+        )
 
     def whitened(self, whitening_filter: FloatArray) -> RegressionData:
         """Return a new dataset with MEG whitened and quadratic forms precomputed.
@@ -449,26 +501,21 @@ class RegressionData:
         ----------
         whitening_filter
             Whitening matrix, typically :attr:`NCRF._whitening_filter`.
-
-        Returns
-        -------
-        :class:`RegressionData`
-            New dataset whose MEG arrays are ``whitening_filter @ meg`` and
-            whose ``_bbt``, ``_bE``, ``_EtE`` quadratic forms are ready for
-            use by the solvers.
         """
-        obj = type(self).__new__(self.__class__)
-        copy_keys = [
-            '_n_predictor_variables', 'basis', 'filter_length', 'tstart', 'tstep', 'tstop',
-            '_stim_is_single', '_stim_dims', '_stim_names', 's_baseline', 's_scaling',
-            'gaussian_fwhm', 's_normalization', '_norm_factor', 'sensor_dim', 'covariates',
-        ]
-        obj.__dict__.update({key: self.__dict__[key] for key in copy_keys})
-        obj.meg = [np.dot(whitening_filter, m) for m in self.meg]
-        obj._bbt = [np.dot(b, b.T) for b in obj.meg]
-        obj._bE = [np.dot(b, E) for b, E in zip(obj.meg, obj.covariates)]
-        obj._EtE = [np.dot(E.T, E) for E in obj.covariates]
-        return obj
+        meg = [np.dot(whitening_filter, m) for m in self.meg]
+        return type(self)(
+            meg, self.covariates, self._norm_factor,
+            basis=self.basis, filter_length=self.filter_length,
+            tstart=self.tstart, tstep=self.tstep, tstop=self.tstop,
+            stim_is_single=self._stim_is_single, stim_dims=self._stim_dims,
+            stim_names=self._stim_names, baseline=self.s_baseline,
+            scaling=self.s_scaling, normalization=self.s_normalization,
+            gaussian_fwhm=self.gaussian_fwhm, sensor_dim=self.sensor_dim,
+            n_predictor_variables=self._n_predictor_variables,
+            bbt=[np.dot(b, b.T) for b in meg],
+            bE=[np.dot(b, E) for b, E in zip(meg, self.covariates)],
+            EtE=[np.dot(E.T, E) for E in self.covariates],
+        )
 
     def __iter__(self) -> Iterator[TrialData]:
         return zip(self.meg, self.covariates)
@@ -486,43 +533,21 @@ class RegressionData:
         ----------
         idx
             Integer indices selecting the time samples to retain.
-
-        Returns
-        -------
-        :class:`RegressionData`
-            A new dataset containing the requested time slice.
         """
-        obj = type(self).__new__(self.__class__)
-        # take care of the copied values from the old_obj
-        copy_keys = ['_n_predictor_variables', 'basis', 'filter_length', 'tstart', 'tstep', 'tstop', '_stim_is_single',
-                     '_stim_dims', '_stim_names', 's_baseline', 's_scaling', 'gaussian_fwhm', 's_normalization']
-        obj.__dict__.update({key: self.__dict__[key] for key in copy_keys})
-        # keep track of the normalization
-        obj._norm_factor = sqrt(len(idx))
-        # add splitted data
-        obj.meg = []
-        obj.covariates = []
-        # Dont forget to take care of the normalization here
-        mul = self._norm_factor / obj._norm_factor  # multiplier to take care of the time normalization
-        for meg, covariate in self:
-            obj.meg.append(meg[:, idx] * mul)
-            obj.covariates.append(covariate[idx, :] * mul)
-
-        return obj
-
-    def post_normalization(self) -> None:
-        """Equalize covariate scales across predictor blocks after construction."""
-        n_vars = sum(len(dim) if dim else 1 for dim in self._stim_dims)
-        if n_vars > 1:
-            start = 0
-            stim_lens = [len(dim) if dim else 1 for dim in self._stim_dims]
-            basis_lengths = [basis.shape[1] for basis in self.basis]
-            basis_lengths = np.repeat(np.asanyarray(basis_lengths), stim_lens)
-            s_normalization = np.asanyarray(self.s_normalization).mean(axis=0)
-            for basis_length, norm in zip(basis_lengths, s_normalization):
-                for covariates in self.covariates:
-                    covariates[:, start:start + basis_length] /= norm
-                start += basis_length
+        norm_factor = sqrt(len(idx))
+        mul = self._norm_factor / norm_factor
+        return type(self)(
+            [m[:, idx] * mul for m in self.meg],
+            [c[idx, :] * mul for c in self.covariates],
+            norm_factor,
+            basis=self.basis, filter_length=self.filter_length,
+            tstart=self.tstart, tstep=self.tstep, tstop=self.tstop,
+            stim_is_single=self._stim_is_single, stim_dims=self._stim_dims,
+            stim_names=self._stim_names, baseline=self.s_baseline,
+            scaling=self.s_scaling, normalization=self.s_normalization,
+            gaussian_fwhm=self.gaussian_fwhm, sensor_dim=self.sensor_dim,
+            n_predictor_variables=self._n_predictor_variables,
+        )
 
 
 class NCRF:

--- a/ncrf/_model.py
+++ b/ncrf/_model.py
@@ -316,10 +316,10 @@ class RegressionData:
 
     def __init__(
             self,
-            meg: list[FloatArray],
-            covariates: list[FloatArray],
+            meg: list[FloatArray],  # (sensor, time)
+            covariates: list[FloatArray],  # (time, covariate)
             norm_factor: float,
-            basis: list[FloatArray],
+            basis: list[FloatArray],  # (filter_time, covariate)
             tstart: list[float],
             tstep: float,
             tstop: list[float],
@@ -328,11 +328,13 @@ class RegressionData:
             stim_names: list[str],
             baseline: Sequence[NDVar | float] | None,
             scaling: Sequence[NDVar | float] | None,
-            stim_normalization: list[list[float]],
+            stim_normalization: list[list[float]],  # (segment, expanded covariate)
             gaussian_fwhm: float,
             sensor_dim: Sensor,
             is_whitened: bool = False,
     ) -> None:
+        if len({m.shape[1] for m in meg}) > 1:
+            raise NotImplementedError(f"Segments with unequal trial length")
         self.meg = meg
         self.covariates = covariates
         self.norm_factor = norm_factor
@@ -415,11 +417,13 @@ class RegressionData:
         tstep = None
         basis = None
         filter_length = None
+        trim = None
         start_samples = None  # in-samples offsets, local to from_data
 
         meg_arrays: list[FloatArray] = []
         covariate_arrays: list[FloatArray] = []
         s_normalization = []
+        trial_length = None
         norm_factor = None
 
         for i_segment, (m, ss) in enumerate(zip(meg, stim)):
@@ -440,6 +444,10 @@ class RegressionData:
                 tstep = meg_time.tstep
             elif meg_time.tstep != tstep:
                 raise ValueError(f"{meg=}: segment {i_segment} time-step incompatible with first segment")
+            if trial_length is None:
+                trial_length = len(meg_time)
+            elif len(meg_time) != trial_length:
+                raise NotImplementedError(f"{meg=}: unequal trial length")
 
             # Determine stim feature dims for this segment
             cur_stim_dims = []
@@ -467,6 +475,8 @@ class RegressionData:
                 start_samples = [int(round(ts / tstep)) for ts in tstart]
                 stop_samples = [int(round(te / tstep)) for te in tstop]
                 filter_length = np.subtract(stop_samples, start_samples) + 1
+                trim = max(filter_length) - 1
+                norm_factor = sqrt(trial_length - trim)
                 basis = []
                 for ts, te, fl in zip(tstart, tstop, filter_length):
                     x = np.linspace(int(round(1000 * ts)), int(round(1000 * te)), fl)
@@ -487,17 +497,14 @@ class RegressionData:
                     s /= sc
 
             # Extract and normalize MEG array
-            m_max = max(b.shape[0] for b in basis)
             y = m.get_data(('sensor', 'time'))
-            y_ = y[:, m_max - 1:].astype(np.float64, copy=False)
+            y_ = y[:, trim:].astype(np.float64, copy=False)
             y = y_ if (in_place or y_.base is None) else y_.copy()
             flat = np.var(y, axis=1) == 0
             if flat.any():
                 raise ValueError(f"{meg=}: segment {i_segment} has flat channels ({', '.join(sensor_dim.names[flat])})")
-            y /= sqrt(y.shape[1])
+            y /= norm_factor
             meg_arrays.append(y)
-            if norm_factor is None:
-                norm_factor = sqrt(y.shape[1])
 
             # Build basis-projected covariate matrix
             stim_lens = [len(d) if d else 1 for d in stim_dims]

--- a/ncrf/_model.py
+++ b/ncrf/_model.py
@@ -425,17 +425,14 @@ class RegressionData:
         """
         if not meg:
             raise ValueError("meg is empty")
-
-        # Validate sensor consistency across segments
-        sensor_dim = meg[0].get_dim('sensor')
-        for m in meg[1:]:
-            if m.get_dim('sensor') != sensor_dim:
-                raise NotImplementedError('combining data segments with different sensors is not supported')
+        elif len(meg) != len(stim):
+            raise ValueError("meg and stim have different lengths")
 
         tstart = list(tstart) if isinstance(tstart, collections.abc.Sequence) else [tstart]
         tstop = list(tstop) if isinstance(tstop, collections.abc.Sequence) else [tstop]
 
-        # State initialized from the first segment
+        # State initialized from the first segment and compared to subsequent segments
+        sensor_dim = None
         stim_dims = None
         stim_names = None
         tstep = None
@@ -449,22 +446,37 @@ class RegressionData:
         norm_factor = None
         n_predictor_variables = 1
 
-        for m, ss in zip(meg, stim):
-            ss = list(ss)
+        for i_segment, (m, ss) in enumerate(zip(meg, stim)):
+            if in_place:
+                ss = list(ss)
+            else:
+                ss = [s.copy() for s in ss]
+
+            # Sensor dim
+            if sensor_dim is None:
+                sensor_dim = m.get_dim('sensor')
+            elif m.get_dim('sensor') != sensor_dim:
+                raise ValueError(f'{meg=}: combining data segments with different sensor configurations is not supported')
+
+            # Time dim
             meg_time: UTS = m.get_dim('time')
+            if tstep is None:
+                tstep = meg_time.tstep
+            elif meg_time.tstep != tstep:
+                raise ValueError(f"{meg=}: segment {i_segment} time-step incompatible with first segment")
 
             # Determine stim feature dims for this segment
             cur_stim_dims = []
             for x in ss:
                 if x.get_dim('time') != meg_time:
-                    raise ValueError(f"stim={x!r}: time axis incompatible with meg")
+                    raise ValueError(f"segment {i_segment} stim {x!r}: time axis incompatible with meg")
                 elif x.ndim == 1:
                     cur_stim_dims.append(None)
                 elif x.ndim == 2:
                     dim, _ = x.get_dims((None, 'time'))
                     cur_stim_dims.append(dim)
                 else:
-                    raise ValueError(f"stim={x!r}: more than 2 dimensions")
+                    raise ValueError(f"Segment {i_segment} stim {x!r}: more than 2 dimensions")
 
             if stim_dims is None:
                 # Initialize time/basis parameters from the first segment
@@ -476,7 +488,6 @@ class RegressionData:
                     tstop = tstop * len(stim_dims)
                 assert len(tstart) == len(stim_dims)
                 assert len(tstop) == len(stim_dims)
-                tstep = meg_time.tstep
                 start_samples = [int(round(ts / tstep)) for ts in tstart]
                 stop_samples = [int(round(te / tstep)) for te in tstop]
                 filter_length = np.subtract(stop_samples, start_samples) + 1
@@ -484,14 +495,10 @@ class RegressionData:
                 for ts, te, fl in zip(tstart, tstop, filter_length):
                     x = np.linspace(int(round(1000 * ts)), int(round(1000 * te)), fl)
                     basis.append(gaussian_basis(int(round((fl - 1) / nlevel)), x))
-            elif meg_time.tstep != tstep:
-                raise ValueError(f"meg={m!r}: incompatible time-step with first segment")
             elif cur_stim_dims != stim_dims:
-                raise ValueError(f"stim dimensions incompatible with first segment")
+                raise ValueError(f"{stim=}: segment {i_segment} dimensions incompatible with first segment")
 
             # Apply stim normalization
-            if not in_place:
-                ss = [s.copy() for s in ss]
             if baseline is not None:
                 if len(baseline) != len(ss):
                     raise ValueError(f"baseline length {len(baseline)} != number of predictors {len(ss)}")
@@ -510,7 +517,7 @@ class RegressionData:
             y = y_ if (in_place or y_.base is None) else y_.copy()
             flat = np.var(y, axis=1) == 0
             if flat.any():
-                raise ValueError(f"meg={m!r}: flat channels ({', '.join(sensor_dim.names[flat])})")
+                raise ValueError(f"{meg=}: segment {i_segment} has flat channels ({', '.join(sensor_dim.names[flat])})")
             y /= sqrt(y.shape[1])
             meg_arrays.append(y)
             if norm_factor is None:

--- a/ncrf/_model.py
+++ b/ncrf/_model.py
@@ -145,7 +145,9 @@ def covariate_from_stim(
     Returns
     -------
     list
-        Covariate matrices, one per expanded predictor channel.
+        Covariate matrices, one per expanded predictor channel. Each matrix has
+        one row per stimulus time sample; rows with incomplete stimulus history are
+        zero-padded.
     """
     ws = []
     for stim in stims:
@@ -158,14 +160,15 @@ def covariate_from_stim(
     ws = ws[0] if len(ws) == 1 else np.concatenate(ws, 0)
     assert len(ws) == len(Ms) == len(starts), f"Length of w ({len(ws)}), Ms ({len(Ms)}), and start ({len(starts)}) should be equal"
 
-    length = ws.shape[1]
+    n_times = ws.shape[1]
     Y = []
-    M_max = max(Ms)
     for w, start, M in zip(ws, starts, Ms):
-        X = np.array(
-            [w[i + M:i:-1] if i > -1 else w[i + M::-1]
-             for i in range(M_max - M - 1, length - M)]
-        )
+        X = np.zeros((n_times, M), dtype=w.dtype)
+        for i in range(n_times):
+            stop = i + 1
+            start_i = max(0, stop - M)
+            n = stop - start_i
+            X[i, :n] = w[start_i:stop][::-1]
         if start != 0:
             # -ve tstart -> shift covariate matrix left
             # +ve tstart -> shift covariate matrix right
@@ -349,6 +352,7 @@ class RegressionData:
             basis_std: float = 0.0085,
             in_place: bool = False,
             post_normalize: bool = True,
+            pad_stim: bool = False,
     ) -> RegressionData:
         """Construct a dataset from MEG and stimulus NDVars.
 
@@ -384,6 +388,10 @@ class RegressionData:
         post_normalize
             If ``True`` (default), equalize covariate scales across predictor
             blocks by dividing each block by its average spectral norm.
+        pad_stim
+            If ``False`` (default), keep only rows whose full lag window is inside
+            the stimulus time axis. If ``True``, retain edge rows with zero-padded
+            covariates.
         """
         if not meg:
             raise ValueError("meg is empty")
@@ -400,9 +408,8 @@ class RegressionData:
         tstep = None
         basis = None
         filter_length = None
-        trim = None
-        start_samples = None  # in-samples offsets, local to from_data
         row_slice = None
+        start_samples = None  # in-samples offsets, local to from_data
 
         meg_arrays: list[FloatArray] = []
         covariate_arrays: list[FloatArray] = []
@@ -459,19 +466,18 @@ class RegressionData:
                 start_samples = [int(round(ts / tstep)) for ts in tstart]
                 stop_samples = [int(round(te / tstep)) for te in tstop]
                 filter_length = np.subtract(stop_samples, start_samples) + 1
-                # ``trim`` matches covariate_from_stim(): it drops the leading
-                # MEG rows that cannot have a complete filter-length history.
-                trim = max(filter_length) - 1
                 basis = []
                 for ts, te, fl in zip(tstart, tstop, filter_length):
                     x = np.linspace(ts, te, fl)
                     basis.append(gaussian_basis(int(round((fl - 1) / nlevel)), x, basis_std))
-                # ``row_slice`` removes rows introduced by rolling non-zero
-                # starts; those edge rows are padding, not observations.
-                drop_start = max(0, *start_samples)
-                drop_stop = max(0, *(-s for s in start_samples))
-                if drop_start or drop_stop:
-                    row_slice = slice(drop_start, -drop_stop if drop_stop else None)
+                if not pad_stim:
+                    # covariate_from_stim() fills the full MEG axis with
+                    # zero-padded lag histories. ``row_slice`` keeps only samples
+                    # whose complete lag window lies inside the stimulus.
+                    drop_start = max(0, *stop_samples)
+                    drop_stop = max(0, *(-s for s in start_samples))
+                    if drop_start or drop_stop:
+                        row_slice = slice(drop_start, -drop_stop if drop_stop else None)
             elif cur_stim_dims != stim_dims:
                 raise ValueError(f"{stim=}: segment {i_segment} dimensions incompatible with first segment")
 
@@ -489,7 +495,7 @@ class RegressionData:
 
             # Extract and normalize MEG array
             y = m.get_data(('sensor', 'time'))
-            y_ = y[:, trim:].astype(np.float64, copy=False)
+            y_ = y.astype(np.float64, copy=False)
             y = y_ if (in_place or y_.base is None) else y_.copy()
 
             # Build basis-projected covariate matrix
@@ -502,7 +508,7 @@ class RegressionData:
                 y = y[:, row_slice]
                 raw_covs = [x[row_slice] for x in raw_covs]
             if not y.shape[1]:
-                raise ValueError(f"{meg=}: no samples remain after applying lag edge trimming")
+                raise ValueError(f"{meg=}: no samples remain after applying lag-validity crop")
             flat = np.var(y, axis=1) == 0
             if flat.any():
                 raise ValueError(f"{meg=}: segment {i_segment} has flat channels ({', '.join(sensor_dim.names[flat])})")

--- a/ncrf/_model.py
+++ b/ncrf/_model.py
@@ -46,22 +46,22 @@ MusArg = Sequence[float] | Literal["auto"] | None
 
 
 def gaussian_basis(
-        nlevel: int,
-        span: npt.ArrayLike,
+        n_atoms: int,
+        lags: npt.ArrayLike,
         basis_std: float = 0.0085,
 ) -> FloatArray:
     """Construct Gabor basis for the TRFs.
 
     Parameters
     ----------
-    nlevel
+    n_atoms
         number of atoms
-    span
-        One-dimensional sample locations covered by the basis functions,
+    lags
+        One-dimensional lag times covered by the basis functions,
         shape ``(n_lags,)``.
     basis_std
         Standard deviation of each Gaussian atom, expressed in the same units
-        as ``span``.
+        as ``lags``.
 
     Returns
     -------
@@ -70,17 +70,14 @@ def gaussian_basis(
         ``n_basis = nlevel - 1``.
     """
     logger = logging.getLogger(__name__)
-    x = np.asarray(span, dtype=np.float64)
-    means = np.linspace(x[0] + x[-1] / nlevel, x[-1] * (1 - 1 / nlevel), num=nlevel - 1)
-    logger.info(f'Using gaussian std = {basis_std}')
-    W = []
-
-    for mean in means:
-        W.append(np.exp(-(x - mean) ** 2 / (2 * basis_std ** 2)))
-
-    W = np.array(W)
-
-    return W.T / np.max(W)
+    logger.info(f'Using gaussian basis with {basis_std=}')
+    lags = np.asarray(lags, dtype=np.float64)
+    lag_start = lags[0]
+    lag_stop = lags[-1]
+    lag_step = (lag_stop - lag_start) / n_atoms
+    centers = np.linspace(lag_start + lag_step, lag_stop - lag_step, num=n_atoms - 1)
+    basis = np.exp(-((lags[:, None] - centers[None, :]) ** 2) / (2 * basis_std ** 2))
+    return basis / basis.max()
 
 
 def g(x: FloatArray, mu: float) -> float:

--- a/ncrf/_model.py
+++ b/ncrf/_model.py
@@ -19,8 +19,7 @@ from multiprocessing import current_process
 from operator import attrgetter
 from typing import Any, Callable, Iterator, Literal, Sequence
 
-from eelbrain import NDVar, Sensor, UTS, fmtxt
-from eelbrain._data_obj import Dimension
+from eelbrain import Categorial, NDVar, Scalar, Sensor, Space, UTS, fmtxt
 import numpy as np
 import numpy.typing as npt
 from scipy import linalg
@@ -43,6 +42,7 @@ ObjectiveFunction = Callable[[FloatArray], float]
 GradientFunction = Callable[[FloatArray], FloatArray]
 MuArg = float | Sequence[float] | Literal["auto"]
 MusArg = Sequence[float] | Literal["auto"] | None
+StimDimensions = Categorial | Scalar | Space
 
 
 def gaussian_basis(
@@ -295,9 +295,7 @@ class RegressionData:
         predictor per segment rather than a list; controls whether
         :attr:`NCRF.h` returns a bare NDVar or a list.
     stim_dims
-        Feature dimension for each predictor: ``None`` for scalar
-        predictors, an eelbrain :class:`~eelbrain._data_obj.Dimension`
-        for multi-feature predictors.
+        Feature dimension for each predictor (``None`` for scalar predictors).
     stim_names
         Name of each predictor variable.
     baseline
@@ -325,7 +323,7 @@ class RegressionData:
     tstep: float
     tstop: list[float]
     stim_is_single: bool
-    stim_dims: list[Dimension | None]
+    stim_dims: list[StimDimensions | None]
     stim_names: list[str]
     baseline: Sequence[NDVar | float] | None
     scaling: Sequence[NDVar | float] | None
@@ -578,7 +576,7 @@ class RegressionData:
         Parameters
         ----------
         whitening_filter
-            Whitening matrix, typically :attr:`NCRF._whitening_filter`.
+            Whitening matrix.
 
         Notes
         -----
@@ -607,7 +605,7 @@ class RegressionData:
     def timeslice(self, idx: Sequence[int] | IndexArray) -> RegressionData:
         """Return a new dataset restricted to selected time indices.
 
-        If this dataset :attr:`is_whitened`, the returned dataset is also
+        If this dataset ``.is_whitened``, the returned dataset is also
         marked as whitened and quadratic forms are recomputed lazily.
 
         Parameters
@@ -654,6 +652,8 @@ class NCRF:
     h
         The neuro-current response function. It is one NDVar when fitting a single
         predictor and a sequence of NDVars when fitting multiple predictors.
+    h_scaled
+        ``h`` with the original stimulus scaling restored.
     explained_var
         Fraction of total variance explained by the fitted NCRFs.
     voxelwise_explained_variance
@@ -664,9 +664,19 @@ class NCRF:
         Data covariance estimates under the model.
     theta
         NCRF coefficients over the Gabor basis.
+    mu
+        Regularization parameter used for the fitted model.
     residual
         The fit error, i.e. the result of the ``eval_obj`` error function on the
         final fit.
+    tstart
+        TRF start time in seconds, one value per predictor.
+    tstep
+        Sample spacing in seconds.
+    tstop
+        TRF stop time in seconds, one value per predictor.
+    basis_std
+        Standard deviation of the Gaussian basis functions in seconds.
     stim_baseline
         Mean that was subtracted from ``stim``.
     stim_scaling

--- a/ncrf/_model.py
+++ b/ncrf/_model.py
@@ -263,8 +263,7 @@ def _compute_gamma_ip(z: FloatArray, x: FloatArray, gamma: FloatArray) -> None:
 class RegressionData:
     """Prepared dataset for NCRF fitting.
 
-    All parameters are stored as instance attributes; where the attribute
-    name differs from the parameter name the attribute name is noted.
+    All parameters are stored as same-named instance attributes.
     Use :meth:`from_data` to construct from raw MEG and stimulus
     :class:`~eelbrain.NDVar` objects.
 
@@ -278,8 +277,7 @@ class RegressionData:
         ``(n_times, n_basis_cols)``.
     norm_factor
         ``sqrt(n_times)`` of the first segment; used by :meth:`timeslice`
-        to rescale sub-segments consistently.  Stored as
-        ``self._norm_factor``.
+        to rescale sub-segments consistently.
     basis
         Gaussian basis matrices, one per predictor variable, each shaped
         ``(filter_length, n_basis)``.
@@ -293,43 +291,41 @@ class RegressionData:
     tstop
         TRF stop time in seconds, one value per predictor.
     stim_is_single
-        ``True`` when the original stimulus input had a single predictor
-        per segment.  Stored as ``self._stim_is_single``.
+        ``True`` when the original stimulus input contained a single
+        predictor per segment rather than a list; controls whether
+        :attr:`NCRF.h` returns a bare NDVar or a list.
     stim_dims
         Feature dimension for each predictor: ``None`` for scalar
         predictors, an eelbrain :class:`~eelbrain._data_obj.Dimension`
-        for multi-feature predictors.  Stored as ``self._stim_dims``.
+        for multi-feature predictors.
     stim_names
-        Name of each predictor variable.  Stored as
-        ``self._stim_names``.
+        Name of each predictor variable.
     baseline
         Per-predictor centering values subtracted before covariate
-        construction, or ``None`` if no centering was applied.  Stored
-        as ``self.s_baseline``.
+        construction, or ``None`` if no centering was applied.
     scaling
         Per-predictor scale factors applied after centering, or ``None``
-        if no scaling was applied.  Stored as ``self.s_scaling``.
-    normalization
+        if no scaling was applied.
+    stim_normalization
         Spectral norms of each predictor block before post-normalization,
-        one inner list per segment.  Stored as ``self.s_normalization``.
+        one inner list per segment.
     gaussian_fwhm
         Full width at half maximum of the Gaussian basis functions in ms.
     sensor_dim
         Sensor dimension shared by all MEG segments.
     n_predictor_variables
         Total number of scalar predictor columns after expanding
-        multi-feature predictors.  Stored as
-        ``self._n_predictor_variables``.
+        multi-feature predictors.
     bbt
         Per-segment ``B @ B.T`` matrices where ``B`` is a whitened MEG
         array; precomputed by :meth:`whitened` for the inner solver loop.
-        When provided, stored as ``self._bbt``.
+        ``None`` on unwhitened datasets.
     bE
         Per-segment ``B @ E`` cross-product matrices; precomputed by
-        :meth:`whitened`.  When provided, stored as ``self._bE``.
+        :meth:`whitened`.  ``None`` on unwhitened datasets.
     EtE
         Per-segment ``E.T @ E`` covariate Gram matrices; precomputed by
-        :meth:`whitened`.  When provided, stored as ``self._EtE``.
+        :meth:`whitened`.  ``None`` on unwhitened datasets.
     """
 
     def __init__(
@@ -348,7 +344,7 @@ class RegressionData:
             stim_names: list[str],
             baseline: Sequence[NDVar | float] | None,
             scaling: Sequence[NDVar | float] | None,
-            normalization: list[list[float]],
+            stim_normalization: list[list[float]],
             gaussian_fwhm: float,
             sensor_dim: Sensor,
             n_predictor_variables: int,
@@ -358,25 +354,24 @@ class RegressionData:
     ) -> None:
         self.meg = meg
         self.covariates = covariates
-        self._norm_factor = norm_factor
+        self.norm_factor = norm_factor
         self.basis = basis
         self.filter_length = filter_length
         self.tstart = tstart
         self.tstep = tstep
         self.tstop = tstop
-        self._stim_is_single = stim_is_single
-        self._stim_dims = stim_dims
-        self._stim_names = stim_names
-        self.s_baseline = baseline
-        self.s_scaling = scaling
-        self.s_normalization = normalization
+        self.stim_is_single = stim_is_single
+        self.stim_dims = stim_dims
+        self.stim_names = stim_names
+        self.baseline = baseline
+        self.scaling = scaling
+        self.stim_normalization = stim_normalization
         self.gaussian_fwhm = gaussian_fwhm
         self.sensor_dim = sensor_dim
-        self._n_predictor_variables = n_predictor_variables
-        if bbt is not None:
-            self._bbt = bbt
-            self._bE = bE
-            self._EtE = EtE
+        self.n_predictor_variables = n_predictor_variables
+        self.bbt = bbt
+        self.bE = bE
+        self.EtE = EtE
 
     @classmethod
     def from_data(
@@ -388,7 +383,7 @@ class RegressionData:
             nlevel: int,
             baseline: Sequence[NDVar | float] | None,
             scaling: Sequence[NDVar | float] | None,
-            stim_is_single: bool,
+            stim_is_single: bool = False,
             gaussian_fwhm: float = 20.0,
             in_place: bool = False,
             post_normalize: bool = True,
@@ -553,9 +548,9 @@ class RegressionData:
             meg_arrays, covariate_arrays, norm_factor,
             basis=basis, filter_length=filter_length,
             tstart=tstart, tstep=tstep, tstop=tstop,
-            stim_is_single=stim_is_single, stim_dims=stim_dims,
-            stim_names=stim_names, baseline=baseline, scaling=scaling,
-            normalization=s_normalization, gaussian_fwhm=gaussian_fwhm,
+            stim_is_single=stim_is_single, stim_dims=stim_dims, stim_names=stim_names,
+            baseline=baseline, scaling=scaling,
+            stim_normalization=s_normalization, gaussian_fwhm=gaussian_fwhm,
             sensor_dim=sensor_dim, n_predictor_variables=n_predictor_variables,
         )
 
@@ -570,15 +565,15 @@ class RegressionData:
             Whitening matrix, typically :attr:`NCRF._whitening_filter`.
         """
         meg = [np.dot(whitening_filter, m) for m in self.meg]
-        return type(self)(
-            meg, self.covariates, self._norm_factor,
+        return RegressionData(
+            meg, self.covariates, self.norm_factor,
             basis=self.basis, filter_length=self.filter_length,
             tstart=self.tstart, tstep=self.tstep, tstop=self.tstop,
-            stim_is_single=self._stim_is_single, stim_dims=self._stim_dims,
-            stim_names=self._stim_names, baseline=self.s_baseline,
-            scaling=self.s_scaling, normalization=self.s_normalization,
+            stim_is_single=self.stim_is_single, stim_dims=self.stim_dims,
+            stim_names=self.stim_names, baseline=self.baseline, scaling=self.scaling,
+            stim_normalization=self.stim_normalization,
             gaussian_fwhm=self.gaussian_fwhm, sensor_dim=self.sensor_dim,
-            n_predictor_variables=self._n_predictor_variables,
+            n_predictor_variables=self.n_predictor_variables,
             bbt=[np.dot(b, b.T) for b in meg],
             bE=[np.dot(b, E) for b, E in zip(meg, self.covariates)],
             EtE=[np.dot(E.T, E) for E in self.covariates],
@@ -602,18 +597,18 @@ class RegressionData:
             Integer indices selecting the time samples to retain.
         """
         norm_factor = sqrt(len(idx))
-        mul = self._norm_factor / norm_factor
-        return type(self)(
+        mul = self.norm_factor / norm_factor
+        return RegressionData(
             [m[:, idx] * mul for m in self.meg],
             [c[idx, :] * mul for c in self.covariates],
             norm_factor,
             basis=self.basis, filter_length=self.filter_length,
             tstart=self.tstart, tstep=self.tstep, tstop=self.tstop,
-            stim_is_single=self._stim_is_single, stim_dims=self._stim_dims,
-            stim_names=self._stim_names, baseline=self.s_baseline,
-            scaling=self.s_scaling, normalization=self.s_normalization,
+            stim_is_single=self.stim_is_single, stim_dims=self.stim_dims,
+            stim_names=self.stim_names, baseline=self.baseline, scaling=self.scaling,
+            stim_normalization=self.stim_normalization,
             gaussian_fwhm=self.gaussian_fwhm, sensor_dim=self.sensor_dim,
-            n_predictor_variables=self._n_predictor_variables,
+            n_predictor_variables=self.n_predictor_variables,
         )
 
 
@@ -831,7 +826,7 @@ class NCRF:
             self.Sigma_b.append(s.copy())
 
         # initializing \Theta
-        l = sum([basis.shape[1] * (len(dim) if dim else 1) for basis, dim in zip(data.basis, data._stim_dims)])
+        l = sum([basis.shape[1] * (len(dim) if dim else 1) for basis, dim in zip(data.basis, data.stim_dims)])
         self.theta = np.zeros((len(self.source) * dc, l), dtype=np.float64)
 
     def _set_mu(self, mu: float, data: RegressionData) -> None:
@@ -1101,12 +1096,12 @@ class NCRF:
 
     def _copy_from_data(self, data: RegressionData) -> None:
         """Copy stimulus metadata needed to rebuild Eelbrain output objects."""
-        self._stim_is_single = data._stim_is_single
-        self._stim_dims = data._stim_dims
-        self._stim_names = data._stim_names
-        self._stim_baseline = data.s_baseline
-        self._stim_scaling = data.s_scaling
-        self._stim_normalization = data.s_normalization
+        self._stim_is_single = data.stim_is_single
+        self._stim_dims = data.stim_dims
+        self._stim_names = data.stim_names
+        self._stim_baseline = data.baseline
+        self._stim_scaling = data.scaling
+        self._stim_normalization = data.stim_normalization
         self._basis = data.basis
         self.tstart = data.tstart
         self.tstep = data.tstep
@@ -1129,13 +1124,13 @@ class NCRF:
                 raise np.linalg.LinAlgError
                 L = linalg.cholesky(self.Sigma_b[i], lower=True)
                 leadfields.append(linalg.solve(L, self._whitened_lead_field))
-                bEs.append(linalg.solve(L, data._bE[i]))
-                bbts.append(np.trace(linalg.solve(L, linalg.solve(L, data._bbt[i]).T)))
+                bEs.append(linalg.solve(L, data.bE[i]))
+                bbts.append(np.trace(linalg.solve(L, linalg.solve(L, data.bbt[i]).T)))
             except np.linalg.LinAlgError:
                 Linv = _inv_sqrtm(self.Sigma_b[i])
                 leadfields.append(np.dot(Linv, self._whitened_lead_field))
-                bEs.append(np.dot(Linv, data._bE[i]))
-                bbts.append(np.trace(np.dot(Linv, np.dot(Linv, data._bbt[i]).T)))
+                bEs.append(np.dot(Linv, data.bE[i]))
+                bbts.append(np.trace(np.dot(Linv, np.dot(Linv, data.bbt[i]).T)))
 
         def f(L, x, bbt, bE, EtE):
             Lx = np.dot(L, x)
@@ -1149,13 +1144,13 @@ class NCRF:
         def funct(x):
             fval = 0.0
             for i in range(len(data)):
-                fval = fval + f(leadfields[i], x, bbts[i], bEs[i], data._EtE[i])
+                fval = fval + f(leadfields[i], x, bbts[i], bEs[i], data.EtE[i])
             return fval
 
         def grad_funct(x):
             grad = gradf(leadfields[0], x, bEs[0], data._EtE[0]).astype(np.float64)
             for i in range(1, len(data)):
-                grad += gradf(leadfields[i], x, bEs[i], data._EtE[i])
+                grad += gradf(leadfields[i], x, bEs[i], data.EtE[i])
             return grad
 
         return funct, grad_funct

--- a/ncrf/_model.py
+++ b/ncrf/_model.py
@@ -402,6 +402,7 @@ class RegressionData:
         filter_length = None
         trim = None
         start_samples = None  # in-samples offsets, local to from_data
+        row_slice = None
 
         meg_arrays: list[FloatArray] = []
         covariate_arrays: list[FloatArray] = []
@@ -458,12 +459,19 @@ class RegressionData:
                 start_samples = [int(round(ts / tstep)) for ts in tstart]
                 stop_samples = [int(round(te / tstep)) for te in tstop]
                 filter_length = np.subtract(stop_samples, start_samples) + 1
+                # ``trim`` matches covariate_from_stim(): it drops the leading
+                # MEG rows that cannot have a complete filter-length history.
                 trim = max(filter_length) - 1
-                norm_factor = sqrt(trial_length - trim)
                 basis = []
                 for ts, te, fl in zip(tstart, tstop, filter_length):
                     x = np.linspace(ts, te, fl)
                     basis.append(gaussian_basis(int(round((fl - 1) / nlevel)), x, basis_std))
+                # ``row_slice`` removes rows introduced by rolling non-zero
+                # starts; those edge rows are padding, not observations.
+                drop_start = max(0, *start_samples)
+                drop_stop = max(0, *(-s for s in start_samples))
+                if drop_start or drop_stop:
+                    row_slice = slice(drop_start, -drop_stop if drop_stop else None)
             elif cur_stim_dims != stim_dims:
                 raise ValueError(f"{stim=}: segment {i_segment} dimensions incompatible with first segment")
 
@@ -483,17 +491,25 @@ class RegressionData:
             y = m.get_data(('sensor', 'time'))
             y_ = y[:, trim:].astype(np.float64, copy=False)
             y = y_ if (in_place or y_.base is None) else y_.copy()
-            flat = np.var(y, axis=1) == 0
-            if flat.any():
-                raise ValueError(f"{meg=}: segment {i_segment} has flat channels ({', '.join(sensor_dim.names[flat])})")
-            y /= norm_factor
-            meg_arrays.append(y)
 
             # Build basis-projected covariate matrix
             stim_lens = [len(d) if d else 1 for d in stim_dims]
             fl_rep = np.repeat(np.asanyarray(filter_length), stim_lens)
             st_rep = np.repeat(np.asanyarray(start_samples), stim_lens)
             raw_covs = covariate_from_stim(ss, fl_rep, st_rep)
+
+            if row_slice is not None:
+                y = y[:, row_slice]
+                raw_covs = [x[row_slice] for x in raw_covs]
+            if not y.shape[1]:
+                raise ValueError(f"{meg=}: no samples remain after applying lag edge trimming")
+            flat = np.var(y, axis=1) == 0
+            if flat.any():
+                raise ValueError(f"{meg=}: segment {i_segment} has flat channels ({', '.join(sensor_dim.names[flat])})")
+            norm_factor = sqrt(y.shape[1])
+            y /= norm_factor
+            meg_arrays.append(y)
+
             i = 0
             covariates = []
             for d, b in zip(stim_dims, basis):

--- a/ncrf/_model.py
+++ b/ncrf/_model.py
@@ -1178,7 +1178,7 @@ class NCRF:
             return fval
 
         def grad_funct(x):
-            grad = gradf(leadfields[0], x, bEs[0], data._EtE[0]).astype(np.float64)
+            grad = gradf(leadfields[0], x, bEs[0], data.EtE[0]).astype(np.float64)
             for i in range(1, len(data)):
                 grad += gradf(leadfields[i], x, bEs[i], data.EtE[i])
             return grad

--- a/ncrf/_model.py
+++ b/ncrf/_model.py
@@ -284,7 +284,6 @@ class RegressionData:
         Full width at half maximum of the Gaussian basis functions, in milliseconds.
     """
     _n_predictor_variables = 1
-    _prewhitened = None
 
     def __init__(
             self,
@@ -441,24 +440,35 @@ class RegressionData:
         x = np.concatenate(covariates, axis=1).astype(np.float64)
         self.covariates.append(x)
 
-    def _prewhiten(self, whitening_filter: FloatArray) -> None:
-        """Apply the model's whitening filter to all stored MEG segments."""
-        if self._prewhitened is None:
-            for i, (meg, _) in enumerate(self):
-                self.meg[i] = np.dot(whitening_filter, meg)
-            self._prewhitened = True
-        else:
-            pass
+    def whitened(self, whitening_filter: FloatArray) -> RegressionData:
+        """Return a new dataset with MEG whitened and quadratic forms precomputed.
 
-    def _precompute(self) -> None:
-        """Cache quadratic forms reused during repeated objective evaluation."""
-        self._bbt = []
-        self._bE = []
-        self._EtE = []
-        for b, E in self:
-            self._bbt.append(np.dot(b, b.T))
-            self._bE.append(np.dot(b, E))
-            self._EtE.append(np.dot(E.T, E))
+        The original dataset is not modified.
+
+        Parameters
+        ----------
+        whitening_filter
+            Whitening matrix, typically :attr:`NCRF._whitening_filter`.
+
+        Returns
+        -------
+        :class:`RegressionData`
+            New dataset whose MEG arrays are ``whitening_filter @ meg`` and
+            whose ``_bbt``, ``_bE``, ``_EtE`` quadratic forms are ready for
+            use by the solvers.
+        """
+        obj = type(self).__new__(self.__class__)
+        copy_keys = [
+            '_n_predictor_variables', 'basis', 'filter_length', 'tstart', 'tstep', 'tstop',
+            '_stim_is_single', '_stim_dims', '_stim_names', 's_baseline', 's_scaling',
+            'gaussian_fwhm', 's_normalization', '_norm_factor', 'sensor_dim', 'covariates',
+        ]
+        obj.__dict__.update({key: self.__dict__[key] for key in copy_keys})
+        obj.meg = [np.dot(whitening_filter, m) for m in self.meg]
+        obj._bbt = [np.dot(b, b.T) for b in obj.meg]
+        obj._bE = [np.dot(b, E) for b, E in zip(obj.meg, obj.covariates)]
+        obj._EtE = [np.dot(E.T, E) for E in obj.covariates]
+        return obj
 
     def __iter__(self) -> Iterator[TrialData]:
         return zip(self.meg, self.covariates)
@@ -485,7 +495,7 @@ class RegressionData:
         obj = type(self).__new__(self.__class__)
         # take care of the copied values from the old_obj
         copy_keys = ['_n_predictor_variables', 'basis', 'filter_length', 'tstart', 'tstep', 'tstop', '_stim_is_single',
-                     '_stim_dims', '_stim_names', 's_baseline', 's_scaling', '_prewhitened', 'gaussian_fwhm', 's_normalization']
+                     '_stim_dims', '_stim_names', 's_baseline', 's_scaling', 'gaussian_fwhm', 's_normalization']
         obj.__dict__.update({key: self.__dict__[key] for key in copy_keys})
         # keep track of the normalization
         obj._norm_factor = sqrt(len(idx))
@@ -736,7 +746,6 @@ class NCRF:
         """Reset the solver state for the requested regularization value."""
         self.mu = mu
         self._init_iter(data)
-        data._precompute()
         if mu == 0.0:
             self._solve(data, self.theta, n_iterc=30)
 
@@ -895,18 +904,16 @@ class NCRF:
             Compute voxel-wise explained variance.
         """
         logger = logging.getLogger(__name__)
-        # pre-whiten data
-        if isinstance(data, RegressionData):
-            data._prewhiten(self._whitening_filter)
+        whitened = data.whitened(self._whitening_filter)
 
         logger.info('Initiating from mne sol, please wait...')
-        self._init_from_mne(data)
+        self._init_from_mne(whitened)
         logger.info('Thanks for waiting...')
 
         # take care of cross-validation
         if do_crossvalidation:
             if mus == 'auto':
-                mus = self._auto_mu(data)
+                mus = self._auto_mu(whitened)
             logger.info('Crossvalidation initiated!')
             cv_results = crossvalidate(self, data, mus, tol, n_splits, n_workers)
             best_cv = min(cv_results, key=attrgetter('cross_fit'))
@@ -951,7 +958,7 @@ class NCRF:
             if mu is None:
                 raise ValueError('mu needs mu to be specified if not \'auto\'')
 
-        self._set_mu(mu, data)
+        self._set_mu(mu, whitened)
 
         if self.space:
             def g_funct(x): return g_group(x, self.mu)
@@ -974,7 +981,7 @@ class NCRF:
         logger.debug('process:iteration \t objective value \t %% change')
         # run iterations
         for i in iter_o:
-            funct, grad_funct = self._construct_f(data)
+            funct, grad_funct = self._construct_f(whitened)
             logger.debug(f"Before FASTA:{funct(self.theta)}")
             Theta = Fasta(funct, g_funct, grad_funct, prox_g, n_iter=self.n_iterf)
             Theta.learn(theta)
@@ -987,18 +994,18 @@ class NCRF:
             if self.err[-1] < tol:
                 break
 
-            self._solve(data, theta)
+            self._solve(whitened, theta)
 
-            self.objective_vals.append(self.eval_obj(data))
+            self.objective_vals.append(self.eval_obj(whitened))
 
             logger.debug(f'{myname}:{i} \t {self.objective_vals[-1]} \t {self.err[-1] * 100}')
 
-        self.residual = self.eval_obj(data)
+        self.residual = self.eval_obj(whitened)
         self._copy_from_data(data)
-        self.explained_var = self.compute_explained_variance(data)
+        self.explained_var = self.compute_explained_variance(whitened)
         if compute_explained_variance:
-            self._voxelwise_explained_variance = self._compute_voxelwise_explained_variance(data)
-        self._data = data  # save the data for further use
+            self._voxelwise_explained_variance = self._compute_voxelwise_explained_variance(whitened)
+        self._data = data  # save the original data for further use
 
     def _copy_from_data(self, data: RegressionData) -> None:
         """Copy stimulus metadata needed to rebuild Eelbrain output objects."""

--- a/ncrf/_model.py
+++ b/ncrf/_model.py
@@ -1023,16 +1023,16 @@ class NCRF:
             Compute voxel-wise explained variance.
         """
         logger = logging.getLogger(__name__)
-        whitened_data = data.whiten(self._whitening_filter)
+        data = data.whiten(self._whitening_filter)
 
         logger.info('Initiating from mne sol, please wait...')
-        self._init_from_mne(whitened_data)
+        self._init_from_mne(data)
         logger.info('Thanks for waiting...')
 
         # take care of cross-validation
         if do_crossvalidation:
             if mus == 'auto':
-                mus = self._auto_mu(whitened_data)
+                mus = self._auto_mu(data)
             logger.info('Crossvalidation initiated!')
             cv_results = crossvalidate(self, data, mus, tol, n_splits, n_workers)
             best_cv = min(cv_results, key=attrgetter('cross_fit'))
@@ -1075,7 +1075,7 @@ class NCRF:
         elif mu is None:  # use the passed mu
             raise TypeError(f'{mu=}: mu needs mu to be a number or "auto"')
 
-        self._set_mu(mu, whitened_data)
+        self._set_mu(mu, data)
 
         if self.space:
             def g_funct(x): return g_group(x, self.mu)
@@ -1098,7 +1098,7 @@ class NCRF:
         logger.debug('process:iteration \t objective value \t %% change')
         # run iterations
         for i in iter_o:
-            funct, grad_funct = self._construct_f(whitened_data)
+            funct, grad_funct = self._construct_f(data)
             logger.debug(f"Before FASTA:{funct(self.theta)}")
             Theta = Fasta(funct, g_funct, grad_funct, prox_g, n_iter=self.n_iterf)
             Theta.learn(theta)
@@ -1111,17 +1111,17 @@ class NCRF:
             if self.err[-1] < tol:
                 break
 
-            self._solve(whitened_data, theta)
+            self._solve(data, theta)
 
-            self.objective_vals.append(self.eval_obj(whitened_data))
+            self.objective_vals.append(self.eval_obj(data))
 
             logger.debug(f'{myname}:{i} \t {self.objective_vals[-1]} \t {self.err[-1] * 100}')
 
-        self.residual = self.eval_obj(whitened_data)
-        self._copy_from_data(whitened_data)
-        self.explained_var = self.compute_explained_variance(whitened_data)
+        self.residual = self.eval_obj(data)
+        self._copy_from_data(data)
+        self.explained_var = self.compute_explained_variance(data)
         if compute_explained_variance:
-            self._voxelwise_explained_variance = self._compute_voxelwise_explained_variance(whitened_data)
+            self._voxelwise_explained_variance = self._compute_voxelwise_explained_variance(data)
         self._data = data  # save the original data for further use
 
     def _copy_from_data(self, data: RegressionData) -> None:

--- a/ncrf/_model.py
+++ b/ncrf/_model.py
@@ -48,7 +48,7 @@ MusArg = Sequence[float] | Literal["auto"] | None
 def gaussian_basis(
         nlevel: int,
         span: npt.ArrayLike,
-        stds: float = 8.5,
+        basis_std: float = 0.0085,
 ) -> FloatArray:
     """Construct Gabor basis for the TRFs.
 
@@ -57,24 +57,26 @@ def gaussian_basis(
     nlevel
         number of atoms
     span
-        One-dimensional sample locations covered by the basis functions.
-    stds
+        One-dimensional sample locations covered by the basis functions,
+        shape ``(n_lags,)``.
+    basis_std
         Standard deviation of each Gaussian atom, expressed in the same units
         as ``span``.
 
     Returns
     -------
     ndarray
-        Array whose columns contain the basis atoms.
+        Array whose columns contain the basis atoms. Shape ``(n_lags, n_basis)``, with
+        ``n_basis = nlevel - 1``.
     """
     logger = logging.getLogger(__name__)
     x = np.asarray(span, dtype=np.float64)
     means = np.linspace(x[0] + x[-1] / nlevel, x[-1] * (1 - 1 / nlevel), num=nlevel - 1)
-    logger.info(f'Using gaussian std = {stds}')
+    logger.info(f'Using gaussian std = {basis_std}')
     W = []
 
     for mean in means:
-        W.append(np.exp(-(x - mean) ** 2 / (2 * stds ** 2)))
+        W.append(np.exp(-(x - mean) ** 2 / (2 * basis_std ** 2)))
 
     W = np.array(W)
 
@@ -307,8 +309,8 @@ class RegressionData:
     stim_normalization
         Spectral norms of each predictor block before post-normalization,
         one inner list per segment.
-    gaussian_fwhm
-        Full width at half maximum of the Gaussian basis functions in ms.
+    basis_std
+        Standard deviation of the Gaussian basis functions in seconds.
     sensor_dim
         Sensor dimension shared by all MEG segments.
     is_whitened
@@ -328,7 +330,7 @@ class RegressionData:
     baseline: Sequence[NDVar | float] | None
     scaling: Sequence[NDVar | float] | None
     stim_normalization: list[list[float]]  # (segment, expanded covariate)
-    gaussian_fwhm: float
+    basis_std: float
     sensor_dim: Sensor
     is_whitened: bool = False
 
@@ -343,11 +345,11 @@ class RegressionData:
             stim: list[Sequence[NDVar]],
             tstart: float | Sequence[float],
             tstop: float | Sequence[float],
-            nlevel: int,
-            baseline: Sequence[NDVar | float] | None,
-            scaling: Sequence[NDVar | float] | None,
+            nlevel: int = 1,
+            baseline: Sequence[NDVar | float] | None = None,
+            scaling: Sequence[NDVar | float] | None = None,
             stim_is_single: bool = False,
-            gaussian_fwhm: float = 20.0,
+            basis_std: float = 0.0085,
             in_place: bool = False,
             post_normalize: bool = True,
     ) -> RegressionData:
@@ -377,8 +379,8 @@ class RegressionData:
             Per-predictor scaling factors applied after baseline subtraction.
         stim_is_single
             Whether the original stimulus input was a single predictor per segment.
-        gaussian_fwhm
-            Full width at half maximum of the Gaussian basis functions, in ms.
+        basis_std
+            Standard deviation of the Gaussian basis functions in seconds.
         in_place
             If ``False`` (default), copies of ``stim`` are made before applying
             baseline subtraction or scaling. Set to ``True`` to modify in place.
@@ -463,8 +465,8 @@ class RegressionData:
                 norm_factor = sqrt(trial_length - trim)
                 basis = []
                 for ts, te, fl in zip(tstart, tstop, filter_length):
-                    x = np.linspace(int(round(1000 * ts)), int(round(1000 * te)), fl)
-                    basis.append(gaussian_basis(int(round((fl - 1) / nlevel)), x))
+                    x = np.linspace(ts, te, fl)
+                    basis.append(gaussian_basis(int(round((fl - 1) / nlevel)), x, basis_std))
             elif cur_stim_dims != stim_dims:
                 raise ValueError(f"{stim=}: segment {i_segment} dimensions incompatible with first segment")
 
@@ -523,7 +525,7 @@ class RegressionData:
             tstart=tstart, tstep=tstep, tstop=tstop,
             stim_is_single=stim_is_single, stim_dims=stim_dims, stim_names=stim_names,
             baseline=baseline, scaling=scaling,
-            stim_normalization=s_normalization, gaussian_fwhm=gaussian_fwhm,
+            stim_normalization=s_normalization, basis_std=basis_std,
             sensor_dim=sensor_dim,
         )
 
@@ -579,7 +581,7 @@ class RegressionData:
             stim_is_single=self.stim_is_single, stim_dims=self.stim_dims,
             stim_names=self.stim_names, baseline=self.baseline, scaling=self.scaling,
             stim_normalization=self.stim_normalization,
-            gaussian_fwhm=self.gaussian_fwhm, sensor_dim=self.sensor_dim,
+            basis_std=self.basis_std, sensor_dim=self.sensor_dim,
             is_whitened=True,
         )
 
@@ -605,7 +607,7 @@ class RegressionData:
             stim_is_single=self.stim_is_single, stim_dims=self.stim_dims,
             stim_names=self.stim_names, baseline=self.baseline, scaling=self.scaling,
             stim_normalization=self.stim_normalization,
-            gaussian_fwhm=self.gaussian_fwhm, sensor_dim=self.sensor_dim,
+            basis_std=self.basis_std, sensor_dim=self.sensor_dim,
             is_whitened=self.is_whitened,
         )
 
@@ -681,7 +683,7 @@ class NCRF:
     residual = None
     mu = None
     theta = None
-    gaussian_fwhm = None
+    basis_std = None
 
     def __init__(
             self,
@@ -720,7 +722,7 @@ class NCRF:
         obj = type(self).__new__(self.__class__)
         copy_keys = ['lead_field', '_whitened_lead_field', 'lead_field_scaling', 'source', 'space', 'sensor',
                      '_whitening_filter', 'noise_covariance', '_whitened_noise_covariance',
-                     'n_iter', 'n_iterc', 'n_iterf', 'eta', 'init_sigma_b', 'gaussian_fwhm']
+                     'n_iter', 'n_iterc', 'n_iterf', 'eta', 'init_sigma_b', 'basis_std']
         for key in copy_keys:
             obj.__dict__.update({key: self.__dict__.get(key, None)})
         return obj
@@ -733,7 +735,7 @@ class NCRF:
         'noise_covariance', 'n_iter', 'n_iterc', 'n_iterf', 'lead_field', '_data',
         'explained_var', '_voxelwise_explained_variance', '_stim_baseline', '_stim_scaling',
         'residual', 'sensor', 'source', 'space', 'theta', 'tstart', 'tstep', 'tstop',
-        'gaussian_fwhm', '_stim_normalization',
+        'basis_std', '_stim_normalization',
     )
 
     def __getstate__(self) -> dict[str, Any]:
@@ -773,8 +775,9 @@ class NCRF:
                         for columns in items.T:
                             _cv_results.append(CVResult(*columns[[0, 1, 4, 2, 3]]))
                 setattr(self, '_cv_results', _cv_results)
-        if self.gaussian_fwhm is None:
-            self.gaussian_fwhm = 20.0  # the default value
+        if self.basis_std is None:
+            # Old bug: basis was always computed using std = 85 ms
+            self.basis_std = 0.0085
 
     def _prewhiten(self) -> None:
         """Compute whitened derived quantities from ``lead_field`` and ``noise_covariance``.
@@ -1109,7 +1112,7 @@ class NCRF:
         self.tstart = data.tstart
         self.tstep = data.tstep
         self.tstop = data.tstop
-        self.gaussian_fwhm = data.gaussian_fwhm
+        self.basis_std = data.basis_std
 
     def _construct_f(self, data: RegressionData) -> tuple[ObjectiveFunction, GradientFunction]:
         """Build the smooth objective and gradient passed to FASTA.

--- a/ncrf/_model.py
+++ b/ncrf/_model.py
@@ -1045,10 +1045,8 @@ class NCRF:
                     else:
                         mu = best_es.mu
 
-        else:
-            # use the passed mu
-            if mu is None:
-                raise ValueError('mu needs mu to be specified if not \'auto\'')
+        elif mu is None:  # use the passed mu
+            raise TypeError(f'{mu=}: mu needs mu to be a number or "auto"')
 
         self._set_mu(mu, whitened)
 

--- a/ncrf/_model.py
+++ b/ncrf/_model.py
@@ -18,7 +18,8 @@ from multiprocessing import current_process
 from operator import attrgetter
 from typing import Any, Callable, Iterator, Literal, Sequence
 
-from eelbrain import NDVar, UTS, fmtxt
+from eelbrain import NDVar, Sensor, UTS, fmtxt
+from eelbrain._data_obj import Dimension
 import numpy as np
 import numpy.typing as npt
 from scipy import linalg
@@ -272,18 +273,18 @@ class RegressionData:
             norm_factor: float,
             *,
             basis: list[FloatArray],
-            filter_length,
+            filter_length: npt.NDArray[np.intp],
             tstart: list[float],
             tstep: float,
             tstop: list[float],
             stim_is_single: bool,
-            stim_dims: list,
+            stim_dims: list[Dimension | None],
             stim_names: list[str],
-            baseline,
-            scaling,
-            normalization: list,
+            baseline: Sequence[NDVar | float] | None,
+            scaling: Sequence[NDVar | float] | None,
+            normalization: list[list[float]],
             gaussian_fwhm: float,
-            sensor_dim,
+            sensor_dim: Sensor,
             n_predictor_variables: int,
             bbt: list[FloatArray] | None = None,
             bE: list[FloatArray] | None = None,

--- a/ncrf/_model.py
+++ b/ncrf/_model.py
@@ -544,7 +544,7 @@ class RegressionData:
             if n_vars > 1:
                 stim_lens = [len(d) if d else 1 for d in stim_dims]
                 bl_lengths = np.repeat([b.shape[1] for b in basis], stim_lens)
-                avg_norm = np.asanyarray(s_normalization).mean(axis=0)
+                avg_norm = np.array(s_normalization).mean(axis=0)
                 col = 0
                 for bl, norm in zip(bl_lengths, avg_norm):
                     for cov in covariate_arrays:
@@ -880,7 +880,7 @@ class NCRF:
         Parameters
         ----------
         data
-            Prepared regression data to fit.
+            Whitened regression data to fit.
         theta
             Coefficients of the TRFs over the Gabor basis.
 
@@ -1122,7 +1122,7 @@ class NCRF:
         self.explained_var = self.compute_explained_variance(data)
         if compute_explained_variance:
             self._voxelwise_explained_variance = self._compute_voxelwise_explained_variance(data)
-        self._data = data  # save the original data for further use
+        self._data = data  # save the data for further use
 
     def _copy_from_data(self, data: RegressionData) -> None:
         """Copy stimulus metadata needed to rebuild Eelbrain output objects."""

--- a/ncrf/_model.py
+++ b/ncrf/_model.py
@@ -263,7 +263,7 @@ def _compute_gamma_ip(z: FloatArray, x: FloatArray, gamma: FloatArray) -> None:
 class RegressionData:
     """Prepared dataset for NCRF fitting.
 
-    All parameters are stored as same-named instance attributes.
+    Constructor parameters are stored as same-named instance attributes.
     Use :meth:`from_data` to construct from raw MEG and stimulus
     :class:`~eelbrain.NDVar` objects.
 
@@ -281,9 +281,6 @@ class RegressionData:
     basis
         Gaussian basis matrices, one per predictor variable, each shaped
         ``(filter_length, n_basis)``.
-    filter_length
-        Number of raw filter taps per predictor, derived from ``tstart``
-        and ``tstop``.
     tstart
         TRF start time in seconds, one value per predictor.
     tstep
@@ -313,19 +310,8 @@ class RegressionData:
         Full width at half maximum of the Gaussian basis functions in ms.
     sensor_dim
         Sensor dimension shared by all MEG segments.
-    n_predictor_variables
-        Total number of scalar predictor columns after expanding
-        multi-feature predictors.
-    bbt
-        Per-segment ``B @ B.T`` matrices where ``B`` is a whitened MEG
-        array; precomputed by :meth:`whiten` for the inner solver loop.
-        ``None`` on unwhitened datasets.
-    bE
-        Per-segment ``B @ E`` cross-product matrices; precomputed by
-        :meth:`whiten`.  ``None`` on unwhitened datasets.
-    EtE
-        Per-segment ``E.T @ E`` covariate Gram matrices; precomputed by
-        :meth:`whiten`.  ``None`` on unwhitened datasets.
+    is_whitened
+        Whether ``meg`` has already been transformed by a whitening filter.
     """
 
     def __init__(
@@ -334,7 +320,6 @@ class RegressionData:
             covariates: list[FloatArray],
             norm_factor: float,
             basis: list[FloatArray],
-            filter_length: npt.NDArray[np.intp],
             tstart: list[float],
             tstep: float,
             tstop: list[float],
@@ -346,16 +331,12 @@ class RegressionData:
             stim_normalization: list[list[float]],
             gaussian_fwhm: float,
             sensor_dim: Sensor,
-            n_predictor_variables: int,
-            bbt: list[FloatArray] | None = None,
-            bE: list[FloatArray] | None = None,
-            EtE: list[FloatArray] | None = None,
+            is_whitened: bool = False,
     ) -> None:
         self.meg = meg
         self.covariates = covariates
         self.norm_factor = norm_factor
         self.basis = basis
-        self.filter_length = filter_length
         self.tstart = tstart
         self.tstep = tstep
         self.tstop = tstop
@@ -367,10 +348,7 @@ class RegressionData:
         self.stim_normalization = stim_normalization
         self.gaussian_fwhm = gaussian_fwhm
         self.sensor_dim = sensor_dim
-        self.n_predictor_variables = n_predictor_variables
-        self.bbt = bbt
-        self.bE = bE
-        self.EtE = EtE
+        self.is_whitened = is_whitened
 
     @classmethod
     def from_data(
@@ -443,7 +421,6 @@ class RegressionData:
         covariate_arrays: list[FloatArray] = []
         s_normalization = []
         norm_factor = None
-        n_predictor_variables = 1
 
         for i_segment, (m, ss) in enumerate(zip(meg, stim)):
             if in_place:
@@ -533,7 +510,6 @@ class RegressionData:
                 l = len(d) if d else 1
                 covariates.extend([np.dot(x, b) / sqrt(y.shape[1]) for x in raw_covs[i:i + l]])
                 i += l
-            n_predictor_variables = len(covariates)
             s_normalization.append([linalg.norm(x, 2) for x in covariates])
             covariate_arrays.append(np.concatenate(covariates, axis=1).astype(np.float64))
 
@@ -552,12 +528,12 @@ class RegressionData:
 
         return cls(
             meg_arrays, covariate_arrays, norm_factor,
-            basis=basis, filter_length=filter_length,
+            basis=basis,
             tstart=tstart, tstep=tstep, tstop=tstop,
             stim_is_single=stim_is_single, stim_dims=stim_dims, stim_names=stim_names,
             baseline=baseline, scaling=scaling,
             stim_normalization=s_normalization, gaussian_fwhm=gaussian_fwhm,
-            sensor_dim=sensor_dim, n_predictor_variables=n_predictor_variables,
+            sensor_dim=sensor_dim,
         )
 
     def __iter__(self) -> Iterator[TrialData]:
@@ -569,13 +545,23 @@ class RegressionData:
     def __repr__(self) -> str:
         return 'Regression data'
 
-    @property
-    def is_whitened(self) -> bool:
-        """Whether this dataset has been whitened (quadratic forms are precomputed)."""
-        return self.bbt is not None
+    @cached_property
+    def bbt(self) -> list[FloatArray]:
+        """Per-segment ``B @ B.T`` matrices for stored MEG arrays."""
+        return [np.dot(b, b.T) for b in self.meg]
+
+    @cached_property
+    def bE(self) -> list[FloatArray]:
+        """Per-segment ``B @ E`` cross-product matrices."""
+        return [np.dot(b, E) for b, E in zip(self.meg, self.covariates)]
+
+    @cached_property
+    def EtE(self) -> list[FloatArray]:
+        """Per-segment ``E.T @ E`` covariate Gram matrices."""
+        return [np.dot(E.T, E) for E in self.covariates]
 
     def whiten(self, whitening_filter: FloatArray) -> RegressionData:
-        """Return a new dataset with MEG whitened and quadratic forms precomputed.
+        """Return a new dataset with MEG whitened.
 
         Parameters
         ----------
@@ -597,23 +583,20 @@ class RegressionData:
         meg = [np.dot(whitening_filter, m) for m in self.meg]
         return RegressionData(
             meg, self.covariates, self.norm_factor,
-            basis=self.basis, filter_length=self.filter_length,
+            basis=self.basis,
             tstart=self.tstart, tstep=self.tstep, tstop=self.tstop,
             stim_is_single=self.stim_is_single, stim_dims=self.stim_dims,
             stim_names=self.stim_names, baseline=self.baseline, scaling=self.scaling,
             stim_normalization=self.stim_normalization,
             gaussian_fwhm=self.gaussian_fwhm, sensor_dim=self.sensor_dim,
-            n_predictor_variables=self.n_predictor_variables,
-            bbt=[np.dot(b, b.T) for b in meg],
-            bE=[np.dot(b, E) for b, E in zip(meg, self.covariates)],
-            EtE=[np.dot(E.T, E) for E in self.covariates],
+            is_whitened=True,
         )
 
     def timeslice(self, idx: Sequence[int] | IndexArray) -> RegressionData:
         """Return a new dataset restricted to selected time indices.
 
-        If this dataset :attr:`is_whitened`, the quadratic forms are recomputed
-        for the slice so the returned dataset is also whitened.
+        If this dataset :attr:`is_whitened`, the returned dataset is also
+        marked as whitened and quadratic forms are recomputed lazily.
 
         Parameters
         ----------
@@ -624,22 +607,15 @@ class RegressionData:
         mul = self.norm_factor / norm_factor
         meg = [m[:, idx] * mul for m in self.meg]
         covariates = [c[idx, :] * mul for c in self.covariates]
-        if self.is_whitened:
-            bbt = [np.dot(b, b.T) for b in meg]
-            bE = [np.dot(b, E) for b, E in zip(meg, covariates)]
-            EtE = [np.dot(E.T, E) for E in covariates]
-        else:
-            bbt = bE = EtE = None
         return RegressionData(
             meg, covariates, norm_factor,
-            basis=self.basis, filter_length=self.filter_length,
+            basis=self.basis,
             tstart=self.tstart, tstep=self.tstep, tstop=self.tstop,
             stim_is_single=self.stim_is_single, stim_dims=self.stim_dims,
             stim_names=self.stim_names, baseline=self.baseline, scaling=self.scaling,
             stim_normalization=self.stim_normalization,
             gaussian_fwhm=self.gaussian_fwhm, sensor_dim=self.sensor_dim,
-            n_predictor_variables=self.n_predictor_variables,
-            bbt=bbt, bE=bE, EtE=EtE,
+            is_whitened=self.is_whitened,
         )
 
 

--- a/ncrf/_model.py
+++ b/ncrf/_model.py
@@ -561,10 +561,17 @@ class RegressionData:
             sensor_dim=sensor_dim, n_predictor_variables=n_predictor_variables,
         )
 
+    def __iter__(self) -> Iterator[TrialData]:
+        return zip(self.meg, self.covariates)
+
+    def __len__(self) -> int:
+        return len(self.meg)
+
+    def __repr__(self) -> str:
+        return 'Regression data'
+
     def whitened(self, whitening_filter: FloatArray) -> RegressionData:
         """Return a new dataset with MEG whitened and quadratic forms precomputed.
-
-        The original dataset is not modified.
 
         Parameters
         ----------
@@ -585,15 +592,6 @@ class RegressionData:
             bE=[np.dot(b, E) for b, E in zip(meg, self.covariates)],
             EtE=[np.dot(E.T, E) for E in self.covariates],
         )
-
-    def __iter__(self) -> Iterator[TrialData]:
-        return zip(self.meg, self.covariates)
-
-    def __len__(self) -> int:
-        return len(self.meg)
-
-    def __repr__(self) -> str:
-        return 'Regression data'
 
     def timeslice(self, idx: Sequence[int] | IndexArray) -> RegressionData:
         """Return a new dataset restricted to selected time indices.

--- a/ncrf/_model.py
+++ b/ncrf/_model.py
@@ -318,14 +318,14 @@ class RegressionData:
         multi-feature predictors.
     bbt
         Per-segment ``B @ B.T`` matrices where ``B`` is a whitened MEG
-        array; precomputed by :meth:`whitened` for the inner solver loop.
+        array; precomputed by :meth:`whiten` for the inner solver loop.
         ``None`` on unwhitened datasets.
     bE
         Per-segment ``B @ E`` cross-product matrices; precomputed by
-        :meth:`whitened`.  ``None`` on unwhitened datasets.
+        :meth:`whiten`.  ``None`` on unwhitened datasets.
     EtE
         Per-segment ``E.T @ E`` covariate Gram matrices; precomputed by
-        :meth:`whitened`.  ``None`` on unwhitened datasets.
+        :meth:`whiten`.  ``None`` on unwhitened datasets.
     """
 
     def __init__(
@@ -570,14 +570,31 @@ class RegressionData:
     def __repr__(self) -> str:
         return 'Regression data'
 
-    def whitened(self, whitening_filter: FloatArray) -> RegressionData:
+    @property
+    def is_whitened(self) -> bool:
+        """Whether this dataset has been whitened (quadratic forms are precomputed)."""
+        return self.bbt is not None
+
+    def whiten(self, whitening_filter: FloatArray) -> RegressionData:
         """Return a new dataset with MEG whitened and quadratic forms precomputed.
 
         Parameters
         ----------
         whitening_filter
             Whitening matrix, typically :attr:`NCRF._whitening_filter`.
+
+        Notes
+        -----
+        Uses shallow copies of unmodified data.
+
+        Raises
+        ------
+        ValueError
+            If the dataset is already whitened. Whitening twice is not equivalent
+            to whitening once with the second filter (``W₂ @ W₁ @ meg ≠ W₂ @ meg``).
         """
+        if self.is_whitened:
+            raise ValueError("Dataset is already whitened; cannot whiten twice")
         meg = [np.dot(whitening_filter, m) for m in self.meg]
         return RegressionData(
             meg, self.covariates, self.norm_factor,
@@ -596,6 +613,9 @@ class RegressionData:
     def timeslice(self, idx: Sequence[int] | IndexArray) -> RegressionData:
         """Return a new dataset restricted to selected time indices.
 
+        If this dataset :attr:`is_whitened`, the quadratic forms are recomputed
+        for the slice so the returned dataset is also whitened.
+
         Parameters
         ----------
         idx
@@ -603,10 +623,16 @@ class RegressionData:
         """
         norm_factor = sqrt(len(idx))
         mul = self.norm_factor / norm_factor
+        meg = [m[:, idx] * mul for m in self.meg]
+        covariates = [c[idx, :] * mul for c in self.covariates]
+        if self.is_whitened:
+            bbt = [np.dot(b, b.T) for b in meg]
+            bE = [np.dot(b, E) for b, E in zip(meg, covariates)]
+            EtE = [np.dot(E.T, E) for E in covariates]
+        else:
+            bbt = bE = EtE = None
         return RegressionData(
-            [m[:, idx] * mul for m in self.meg],
-            [c[idx, :] * mul for c in self.covariates],
-            norm_factor,
+            meg, covariates, norm_factor,
             basis=self.basis, filter_length=self.filter_length,
             tstart=self.tstart, tstep=self.tstep, tstop=self.tstop,
             stim_is_single=self.stim_is_single, stim_dims=self.stim_dims,
@@ -614,6 +640,7 @@ class RegressionData:
             stim_normalization=self.stim_normalization,
             gaussian_fwhm=self.gaussian_fwhm, sensor_dim=self.sensor_dim,
             n_predictor_variables=self.n_predictor_variables,
+            bbt=bbt, bE=bE, EtE=EtE,
         )
 
 
@@ -996,16 +1023,16 @@ class NCRF:
             Compute voxel-wise explained variance.
         """
         logger = logging.getLogger(__name__)
-        whitened = data.whitened(self._whitening_filter)
+        whitened_data = data.whiten(self._whitening_filter)
 
         logger.info('Initiating from mne sol, please wait...')
-        self._init_from_mne(whitened)
+        self._init_from_mne(whitened_data)
         logger.info('Thanks for waiting...')
 
         # take care of cross-validation
         if do_crossvalidation:
             if mus == 'auto':
-                mus = self._auto_mu(whitened)
+                mus = self._auto_mu(whitened_data)
             logger.info('Crossvalidation initiated!')
             cv_results = crossvalidate(self, data, mus, tol, n_splits, n_workers)
             best_cv = min(cv_results, key=attrgetter('cross_fit'))
@@ -1048,7 +1075,7 @@ class NCRF:
         elif mu is None:  # use the passed mu
             raise TypeError(f'{mu=}: mu needs mu to be a number or "auto"')
 
-        self._set_mu(mu, whitened)
+        self._set_mu(mu, whitened_data)
 
         if self.space:
             def g_funct(x): return g_group(x, self.mu)
@@ -1071,7 +1098,7 @@ class NCRF:
         logger.debug('process:iteration \t objective value \t %% change')
         # run iterations
         for i in iter_o:
-            funct, grad_funct = self._construct_f(whitened)
+            funct, grad_funct = self._construct_f(whitened_data)
             logger.debug(f"Before FASTA:{funct(self.theta)}")
             Theta = Fasta(funct, g_funct, grad_funct, prox_g, n_iter=self.n_iterf)
             Theta.learn(theta)
@@ -1084,17 +1111,17 @@ class NCRF:
             if self.err[-1] < tol:
                 break
 
-            self._solve(whitened, theta)
+            self._solve(whitened_data, theta)
 
-            self.objective_vals.append(self.eval_obj(whitened))
+            self.objective_vals.append(self.eval_obj(whitened_data))
 
             logger.debug(f'{myname}:{i} \t {self.objective_vals[-1]} \t {self.err[-1] * 100}')
 
-        self.residual = self.eval_obj(whitened)
-        self._copy_from_data(data)
-        self.explained_var = self.compute_explained_variance(whitened)
+        self.residual = self.eval_obj(whitened_data)
+        self._copy_from_data(whitened_data)
+        self.explained_var = self.compute_explained_variance(whitened_data)
         if compute_explained_variance:
-            self._voxelwise_explained_variance = self._compute_voxelwise_explained_variance(whitened)
+            self._voxelwise_explained_variance = self._compute_voxelwise_explained_variance(whitened_data)
         self._data = data  # save the original data for further use
 
     def _copy_from_data(self, data: RegressionData) -> None:

--- a/ncrf/_model.py
+++ b/ncrf/_model.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import time
 import copy
 import collections
+from dataclasses import dataclass
 from functools import cached_property
 from math import sqrt, log10
 from multiprocessing import current_process
@@ -260,11 +261,11 @@ def _compute_gamma_ip(z: FloatArray, x: FloatArray, gamma: FloatArray) -> None:
     return
 
 
+@dataclass(eq=False, repr=False)
 class RegressionData:
     """Prepared dataset for NCRF fitting.
 
-    Constructor parameters are stored as same-named instance attributes.
-    Use :meth:`from_data` to construct from raw MEG and stimulus
+    Use :meth:`from_data` to construct a dataset from raw MEG and stimulus
     :class:`~eelbrain.NDVar` objects.
 
     Parameters
@@ -314,43 +315,26 @@ class RegressionData:
         Whether ``meg`` has already been transformed by a whitening filter.
     """
 
-    def __init__(
-            self,
-            meg: list[FloatArray],  # (sensor, time)
-            covariates: list[FloatArray],  # (time, covariate)
-            norm_factor: float,
-            basis: list[FloatArray],  # (filter_time, covariate)
-            tstart: list[float],
-            tstep: float,
-            tstop: list[float],
-            stim_is_single: bool,
-            stim_dims: list[Dimension | None],
-            stim_names: list[str],
-            baseline: Sequence[NDVar | float] | None,
-            scaling: Sequence[NDVar | float] | None,
-            stim_normalization: list[list[float]],  # (segment, expanded covariate)
-            gaussian_fwhm: float,
-            sensor_dim: Sensor,
-            is_whitened: bool = False,
-    ) -> None:
-        if len({m.shape[1] for m in meg}) > 1:
-            raise NotImplementedError(f"Segments with unequal trial length")
-        self.meg = meg
-        self.covariates = covariates
-        self.norm_factor = norm_factor
-        self.basis = basis
-        self.tstart = tstart
-        self.tstep = tstep
-        self.tstop = tstop
-        self.stim_is_single = stim_is_single
-        self.stim_dims = stim_dims
-        self.stim_names = stim_names
-        self.baseline = baseline
-        self.scaling = scaling
-        self.stim_normalization = stim_normalization
-        self.gaussian_fwhm = gaussian_fwhm
-        self.sensor_dim = sensor_dim
-        self.is_whitened = is_whitened
+    meg: list[FloatArray]  # (sensor, time)
+    covariates: list[FloatArray]  # (time, covariate)
+    norm_factor: float
+    basis: list[FloatArray]  # (filter_time, covariate)
+    tstart: list[float]
+    tstep: float
+    tstop: list[float]
+    stim_is_single: bool
+    stim_dims: list[Dimension | None]
+    stim_names: list[str]
+    baseline: Sequence[NDVar | float] | None
+    scaling: Sequence[NDVar | float] | None
+    stim_normalization: list[list[float]]  # (segment, expanded covariate)
+    gaussian_fwhm: float
+    sensor_dim: Sensor
+    is_whitened: bool = False
+
+    def __post_init__(self) -> None:
+        if len({m.shape[1] for m in self.meg}) > 1:
+            raise NotImplementedError("Segments with unequal trial length")
 
     @classmethod
     def from_data(

--- a/ncrf/_model.py
+++ b/ncrf/_model.py
@@ -261,9 +261,75 @@ def _compute_gamma_ip(z: FloatArray, x: FloatArray, gamma: FloatArray) -> None:
 
 
 class RegressionData:
-    """Prepared regression dataset for NCRF fitting.
+    """Prepared dataset for NCRF fitting.
 
-    Use :meth:`from_data` to construct from raw MEG and stimulus NDVars.
+    All parameters are stored as instance attributes; where the attribute
+    name differs from the parameter name the attribute name is noted.
+    Use :meth:`from_data` to construct from raw MEG and stimulus
+    :class:`~eelbrain.NDVar` objects.
+
+    Parameters
+    ----------
+    meg
+        MEG signal arrays, one per segment, each shaped
+        ``(n_sensors, n_times)``.
+    covariates
+        Basis-projected covariate matrices, one per segment, each shaped
+        ``(n_times, n_basis_cols)``.
+    norm_factor
+        ``sqrt(n_times)`` of the first segment; used by :meth:`timeslice`
+        to rescale sub-segments consistently.  Stored as
+        ``self._norm_factor``.
+    basis
+        Gaussian basis matrices, one per predictor variable, each shaped
+        ``(filter_length, n_basis)``.
+    filter_length
+        Number of raw filter taps per predictor, derived from ``tstart``
+        and ``tstop``.
+    tstart
+        TRF start time in seconds, one value per predictor.
+    tstep
+        Sample spacing in seconds, shared by all segments.
+    tstop
+        TRF stop time in seconds, one value per predictor.
+    stim_is_single
+        ``True`` when the original stimulus input had a single predictor
+        per segment.  Stored as ``self._stim_is_single``.
+    stim_dims
+        Feature dimension for each predictor: ``None`` for scalar
+        predictors, an eelbrain :class:`~eelbrain._data_obj.Dimension`
+        for multi-feature predictors.  Stored as ``self._stim_dims``.
+    stim_names
+        Name of each predictor variable.  Stored as
+        ``self._stim_names``.
+    baseline
+        Per-predictor centering values subtracted before covariate
+        construction, or ``None`` if no centering was applied.  Stored
+        as ``self.s_baseline``.
+    scaling
+        Per-predictor scale factors applied after centering, or ``None``
+        if no scaling was applied.  Stored as ``self.s_scaling``.
+    normalization
+        Spectral norms of each predictor block before post-normalization,
+        one inner list per segment.  Stored as ``self.s_normalization``.
+    gaussian_fwhm
+        Full width at half maximum of the Gaussian basis functions in ms.
+    sensor_dim
+        Sensor dimension shared by all MEG segments.
+    n_predictor_variables
+        Total number of scalar predictor columns after expanding
+        multi-feature predictors.  Stored as
+        ``self._n_predictor_variables``.
+    bbt
+        Per-segment ``B @ B.T`` matrices where ``B`` is a whitened MEG
+        array; precomputed by :meth:`whitened` for the inner solver loop.
+        When provided, stored as ``self._bbt``.
+    bE
+        Per-segment ``B @ E`` cross-product matrices; precomputed by
+        :meth:`whitened`.  When provided, stored as ``self._bE``.
+    EtE
+        Per-segment ``E.T @ E`` covariate Gram matrices; precomputed by
+        :meth:`whitened`.  When provided, stored as ``self._EtE``.
     """
 
     def __init__(

--- a/ncrf/_model.py
+++ b/ncrf/_model.py
@@ -987,6 +987,7 @@ class NCRF:
             n_splits: int = None,
             n_workers: int = None,
             compute_explained_variance: bool = False,
+            accept_whitening: bool = False,
     ) -> None:
         """Fit the NCRF model to prepared regression data.
 
@@ -1021,9 +1022,16 @@ class NCRF:
             ``0`` to run without :mod:`multiprocessing`.
         compute_explained_variance
             Compute voxel-wise explained variance.
+        accept_whitening
+            Accept pre-whitened data. This is intended for internal workflows
+            that slice an already-whitened dataset, such as cross-validation.
         """
         logger = logging.getLogger(__name__)
-        data = data.whiten(self._whitening_filter)
+        if data.is_whitened:
+            if not accept_whitening:
+                raise ValueError("data is already whitened; pass accept_whitening=True to accept it")
+        else:
+            data = data.whiten(self._whitening_filter)
 
         logger.info('Initiating from mne sol, please wait...')
         self._init_from_mne(data)
@@ -1439,7 +1447,7 @@ class NCRF:
             for model_, (train, test) in zip(models_, kf.split(data.meg[0][0])):
                 traindata = data.timeslice(train)
                 testdata = data.timeslice(test)
-                model_.fit(traindata, mu, tol=tol, verbose=False)
+                model_.fit(traindata, mu, tol=tol, verbose=False, accept_whitening=True)
                 obj, wl2 = model_.eval_obj(testdata, True)
                 ll.append(wl2)
                 ll1.append(obj)

--- a/ncrf/_ncrf.py
+++ b/ncrf/_ncrf.py
@@ -259,13 +259,11 @@ def fit_ncrf(
     else:
         raise TypeError(f"{normalize=}, need bool or str")
 
-    # Call `REG_Data.add_data` once for each contiguous segment of MEG data
-    ds = RegressionData(tstart, tstop, nlevels, s_baseline, s_scale, stim_is_single, gaussian_fwhm)
-    for r, ss in zip(meg_trials, stim_trials):
-        ds.add_data(r, ss, in_place=in_place)
-
-    if do_post_normalization:
-        ds.post_normalization()
+    ds = RegressionData.from_data(
+        meg_trials, stim_trials, tstart, tstop, nlevels,
+        s_baseline, s_scale, stim_is_single, gaussian_fwhm,
+        in_place=in_place, post_normalize=do_post_normalization,
+    )
 
     # noise covariance
     noise_cov = _handle_noise_channels(noise, ds.sensor_dim)

--- a/ncrf/_ncrf.py
+++ b/ncrf/_ncrf.py
@@ -86,7 +86,7 @@ def fit_ncrf(
         n_splits: int = 3,
         n_workers: int | None = None,
         use_ES: bool = False,
-        gaussian_fwhm: float = 20.0,
+        basis_std: float = 0.0085,
         do_post_normalization: bool = True,
 ) -> NCRF:
     r"""One shot function for cortical TRF localization.
@@ -155,14 +155,14 @@ def fit_ncrf(
     use_ES
         Use estimation stability criterion :cite:`limEstimationStabilityCrossValidation2016` to
         choose the best ``mu``. (False, by default)
-    gaussian_fwhm
-        Specifies the full width half maximum (fwmh) for the Gaussian kernel (used as elements of
-        the time basis), the default is 20 ms. The standard deviation (std) is related to the
-        fwmh as following:
+    basis_std
+        Standard deviation of the Gaussian basis atoms in seconds
+        (default ``0.0085``, approximately 20 ms FWHM).
+        The standard deviation (std) is related to the fwmh by:
         :math:`std = fwhm / (2 * (sqrt(2 * log(2))))`.
     do_post_normalization
         Scales covariate matrices of different predictor variables by spectral norms to
-        equalize their spectral spread (=1). (True, by default)
+        equalize their spectral spread (=1). (default ``True``)
 
     Returns
     -------
@@ -261,7 +261,7 @@ def fit_ncrf(
 
     ds = RegressionData.from_data(
         meg_trials, stim_trials, tstart, tstop, nlevels,
-        s_baseline, s_scale, stim_is_single, gaussian_fwhm,
+        s_baseline, s_scale, stim_is_single, basis_std=basis_std,
         in_place=in_place, post_normalize=do_post_normalization,
     )
 

--- a/ncrf/tests/test_model.py
+++ b/ncrf/tests/test_model.py
@@ -45,5 +45,5 @@ def test_covariate_from_stim():
     filter_lengths = np.subtract(stop, start) + 1
     covariates_shift = covariate_from_stim([stim], filter_lengths, start)
 
-    np.testing.assert_array_equal(covariates[0].T[:, 0:100], covariates_shift[0].T[:, 20:120])  # Beginning
-    np.testing.assert_array_equal(covariates[0].T[:, -120:-20], covariates_shift[0].T[:, -100:])  # End
+    assert covariates[0].shape[0] == len(stim.get_dim('time'))
+    np.testing.assert_array_equal(covariates[0][:-20], covariates_shift[0][20:])

--- a/ncrf/tests/test_model.py
+++ b/ncrf/tests/test_model.py
@@ -4,10 +4,18 @@
 # License: BSD (3-clause)
 import numpy as np
 
-from ncrf._model import covariate_from_stim
+from ncrf._model import covariate_from_stim, gaussian_basis
 from .fetch import load
 
 from eelbrain import Categorial, concatenate
+
+
+def test_gaussian_basis():
+    basis = gaussian_basis(5, np.linspace(0, 1, 11), 0.1)
+    shifted_basis = gaussian_basis(5, np.linspace(10, 11, 11), 0.1)
+
+    assert basis.shape == (11, 4)
+    np.testing.assert_allclose(basis, shifted_basis)
 
 
 def test_covariate_from_stim():

--- a/ncrf/tests/test_ncrf.py
+++ b/ncrf/tests/test_ncrf.py
@@ -64,15 +64,15 @@ def test_ncrf():
                      n_iterc=3, n_iterf=10, do_post_normalization=False)
 
     # check residual and explained var
-    np.testing.assert_allclose(model.explained_var, 0.02148945636352262, rtol=0.001)
-    np.testing.assert_allclose(model.residual, 176.953, rtol=0.001)
+    np.testing.assert_allclose(model.explained_var, 0.021442823238037034, rtol=0.001)
+    np.testing.assert_allclose(model.residual, 177.15021740565106, rtol=0.001)
     # check start and stop
     np.testing.assert_equal(model.tstart, tstart)
     np.testing.assert_equal(model.tstop, tstop)
     # check scaling
     np.testing.assert_equal(model._stim_baseline[0], stim.mean())
     np.testing.assert_equal(model._stim_scaling[0], stim.std())
-    np.testing.assert_allclose(model.h[0].norm('time').norm('source').norm('space'), 5.9598e-10, rtol=0.001)
+    np.testing.assert_allclose(model.h[0].norm('time').norm('source').norm('space'), 6.6065539e-10, rtol=0.001)
 
     # cross-validation
     model = fit_ncrf(meg, stim, fwd, emptyroom, tstop=0.2, normalize='l1', mu='auto', n_iter=1, n_iterc=2, n_iterf=2, do_post_normalization=False)
@@ -109,20 +109,18 @@ def test_ncrf_shifted_nonzero_lags():
     stim_positive = set_tmin(stim.sub(time=(segment_start, segment_stop + shift)), 0)
     meg_positive = set_time(set_tmin(meg, shift - segment_start), stim_positive)
 
-    # Negative lag fit: include ``shift`` extra predictor samples at the start.
-    # After dropping the last ``shift`` invalid design rows, this again uses the
-    # same predictor and MEG samples as the baseline fit.
-    stim_negative = set_tmin(stim.sub(time=(segment_start - shift, segment_stop)), 0)
-    meg_negative = set_time(set_tmin(meg, -segment_start), stim_negative)
+    # Negative lag fit: keep the predictor window fixed and shift the MEG labels.
+    # After dropping the last ``shift`` invalid design rows, the remaining rows
+    # use the same predictor and MEG samples as the baseline fit.
+    meg_negative = set_time(set_tmin(meg, -shift - segment_start), stim_segment)
 
     # Guard the test setup itself: all three fits should differ only in the
     # time labels/lag windows, not in the effective numeric samples.
     lag_samples = int(round(lag_stop / tstep))
     shift_samples = int(round(shift / tstep))
     np.testing.assert_array_equal(stim_positive.x[:-shift_samples], stim_segment.x)
-    np.testing.assert_array_equal(stim_negative.x[shift_samples:], stim_segment.x)
     np.testing.assert_array_equal(meg_positive.x[:, lag_samples + shift_samples:], meg_0.x[:, lag_samples:])
-    np.testing.assert_array_equal(meg_negative.x[:, lag_samples:-shift_samples], meg_0.x[:, lag_samples:])
+    np.testing.assert_array_equal(meg_negative.x[:, shift_samples:-shift_samples], meg_0.x[:, lag_samples:])
 
     fit_kwargs = dict(
         mu=0.001,
@@ -141,7 +139,7 @@ def test_ncrf_shifted_nonzero_lags():
         tstop=lag_stop + shift, **fit_kwargs,
     )
     model_negative = fit_ncrf(
-        meg_negative, stim_negative, fwd, emptyroom, tstart=-shift,
+        meg_negative, stim_segment, fwd, emptyroom, tstart=-shift,
         tstop=lag_stop - shift, **fit_kwargs,
     )
 

--- a/ncrf/tests/test_ncrf.py
+++ b/ncrf/tests/test_ncrf.py
@@ -95,18 +95,39 @@ def test_ncrf_shifted_nonzero_lags():
     fwd = load('fwd_sol')
     emptyroom = load('emptyroom')
 
-    # Get a short excerpt from the test data
+    # Use a short interior excerpt so the shifted windows below can extend by
+    # ``shift`` without running past the available test data.
     tstep = meg.get_dim('time').tstep
     segment_start = 20 * tstep
-    segment_stop = segment_start + 80 * tstep
+    shift = 5 * tstep
+    lag_stop = 10 * tstep
+    segment_stop = segment_start + 75 * tstep
+
+    # Baseline fit: predictor and MEG share the same 75-sample window, and the
+    # model estimates lags from 0 to ``lag_stop``.
     stim_segment = set_tmin(stim.sub(time=(segment_start, segment_stop)), 0)
     meg_0 = set_time(set_tmin(meg, -segment_start), stim_segment)
 
-    # Create meg data arrays with a shift relative to the predictor
-    shift = 5 * tstep
-    lag_stop = 10 * tstep
-    meg_positive = set_time(set_tmin(meg, shift - segment_start), stim_segment)
-    meg_negative = set_time(set_tmin(meg, -shift - segment_start), stim_segment)
+    # Positive lag fit: include ``shift`` extra predictor samples at the end.
+    # After dropping the first ``shift`` invalid design rows, this uses the same
+    # predictor and MEG samples as the baseline fit.
+    stim_positive = set_tmin(stim.sub(time=(segment_start, segment_stop + shift)), 0)
+    meg_positive = set_time(set_tmin(meg, shift - segment_start), stim_positive)
+
+    # Negative lag fit: include ``shift`` extra predictor samples at the start.
+    # After dropping the last ``shift`` invalid design rows, this again uses the
+    # same predictor and MEG samples as the baseline fit.
+    stim_negative = set_tmin(stim.sub(time=(segment_start - shift, segment_stop)), 0)
+    meg_negative = set_time(set_tmin(meg, -segment_start), stim_negative)
+
+    # Guard the test setup itself: all three fits should differ only in the
+    # time labels/lag windows, not in the effective numeric samples.
+    lag_samples = int(round(lag_stop / tstep))
+    shift_samples = int(round(shift / tstep))
+    np.testing.assert_array_equal(stim_positive.x[:-shift_samples], stim_segment.x)
+    np.testing.assert_array_equal(stim_negative.x[shift_samples:], stim_segment.x)
+    np.testing.assert_array_equal(meg_positive.x[:, lag_samples + shift_samples:], meg_0.x[:, lag_samples:])
+    np.testing.assert_array_equal(meg_negative.x[:, lag_samples:-shift_samples], meg_0.x[:, lag_samples:])
 
     fit_kwargs = dict(
         mu=0.001,
@@ -121,11 +142,11 @@ def test_ncrf_shifted_nonzero_lags():
         meg_0, stim_segment, fwd, emptyroom, tstart=0, tstop=lag_stop, **fit_kwargs,
     )
     model_positive = fit_ncrf(
-        meg_positive, stim_segment, fwd, emptyroom, tstart=shift,
+        meg_positive, stim_positive, fwd, emptyroom, tstart=shift,
         tstop=lag_stop + shift, **fit_kwargs,
     )
     model_negative = fit_ncrf(
-        meg_negative, stim_segment, fwd, emptyroom, tstart=-shift,
+        meg_negative, stim_negative, fwd, emptyroom, tstart=-shift,
         tstop=lag_stop - shift, **fit_kwargs,
     )
 

--- a/ncrf/tests/test_ncrf.py
+++ b/ncrf/tests/test_ncrf.py
@@ -39,12 +39,12 @@ def test_ncrf():
     assert_dataobj_equal(model_2.h, model.h)
     assert_dataobj_equal(model_2.h_scaled, model.h_scaled)
     np.testing.assert_equal(model_2.residual, model.residual)
-    np.testing.assert_equal(model_2.gaussian_fwhm, model.gaussian_fwhm)
+    np.testing.assert_equal(model_2.basis_std, model.basis_std)
 
-    # test gaussian fwhm
+    # test Gaussian basis standard deviation
     model = fit_ncrf(meg, stim, fwd, emptyroom, tstop=0.2, normalize='l1', mu=0.0019444, n_iter=1, n_iterc=1,
-                     n_iterf=1, gaussian_fwhm=50.0)
-    assert model.gaussian_fwhm == 50.0
+                     n_iterf=1, basis_std=0.050)
+    assert model.basis_std == 0.050
 
     # 2 stimuli, one of them 2-d, normalize='l2'
     diff = stim.diff('time')

--- a/ncrf/tests/test_ncrf.py
+++ b/ncrf/tests/test_ncrf.py
@@ -3,7 +3,10 @@
 # Author: Proloy Das <email:proloyd94@gmail.com>
 # License: BSD (3-clause)
 import pickle
+
+from eelbrain import set_time, set_tmin
 import numpy as np
+import pytest
 
 from ncrf import fit_ncrf
 from ncrf.tests.fetch import load
@@ -80,3 +83,54 @@ def test_ncrf():
     # test without multiprocessing
     model_no_mp = fit_ncrf(meg, stim, fwd, emptyroom, tstop=0.2, normalize='l1', mu='auto', n_iter=1, n_iterc=2, n_iterf=2, n_workers=0, do_post_normalization=False)
     assert_dataobj_equal(model_no_mp.h, model.h)
+
+
+@pytest.mark.xfail(
+    reason="fit_ncrf currently includes padded edge rows for shifted non-zero lags",
+    strict=True,
+)
+def test_ncrf_shifted_nonzero_lags():
+    meg = load('meg').sub(case=0)
+    stim = load('stim').sub(case=0)
+    fwd = load('fwd_sol')
+    emptyroom = load('emptyroom')
+
+    # Get a short excerpt from the test data
+    tstep = meg.get_dim('time').tstep
+    segment_start = 20 * tstep
+    segment_stop = segment_start + 80 * tstep
+    stim_segment = set_tmin(stim.sub(time=(segment_start, segment_stop)), 0)
+    meg_0 = set_time(set_tmin(meg, -segment_start), stim_segment)
+
+    # Create meg data arrays with a shift relative to the predictor
+    shift = 5 * tstep
+    lag_stop = 10 * tstep
+    meg_positive = set_time(set_tmin(meg, shift - segment_start), stim_segment)
+    meg_negative = set_time(set_tmin(meg, -shift - segment_start), stim_segment)
+
+    fit_kwargs = dict(
+        mu=0.001,
+        tol=0,
+        verbose=False,
+        n_iter=1,
+        n_iterc=1,
+        n_iterf=5,
+        do_post_normalization=False,
+    )
+    model_0 = fit_ncrf(
+        meg_0, stim_segment, fwd, emptyroom, tstart=0, tstop=lag_stop, **fit_kwargs,
+    )
+    model_positive = fit_ncrf(
+        meg_positive, stim_segment, fwd, emptyroom, tstart=shift,
+        tstop=lag_stop + shift, **fit_kwargs,
+    )
+    model_negative = fit_ncrf(
+        meg_negative, stim_segment, fwd, emptyroom, tstart=-shift,
+        tstop=lag_stop - shift, **fit_kwargs,
+    )
+
+    assert np.linalg.norm(model_0.theta) > 0
+    for model_shifted in (model_positive, model_negative):
+        np.testing.assert_allclose(model_shifted.theta, model_0.theta)
+        np.testing.assert_allclose(model_shifted.residual, model_0.residual)
+        np.testing.assert_allclose(model_shifted.explained_var, model_0.explained_var)

--- a/ncrf/tests/test_ncrf.py
+++ b/ncrf/tests/test_ncrf.py
@@ -6,7 +6,6 @@ import pickle
 
 from eelbrain import set_time, set_tmin
 import numpy as np
-import pytest
 
 from ncrf import fit_ncrf
 from ncrf.tests.fetch import load
@@ -85,10 +84,6 @@ def test_ncrf():
     assert_dataobj_equal(model_no_mp.h, model.h)
 
 
-@pytest.mark.xfail(
-    reason="fit_ncrf currently includes padded edge rows for shifted non-zero lags",
-    strict=True,
-)
 def test_ncrf_shifted_nonzero_lags():
     meg = load('meg').sub(case=0)
     stim = load('stim').sub(case=0)


### PR DESCRIPTION
- Turned `RegressionData` from a stateful object (with attributes changing over the course of its lifespan) into a static dataset. That decreases the chance of unexpected side effects when the dataset changes.
- `RegressionData.from_data()` for building the dataset from MEG data .
- Whitening is now explicit and non-mutating: `RegressionData.whiten()` returns a new object and `is_whitened` prevents accidental double-whitening.

Along the way I found some issues with data preparation, some mentioned in #59  which added a test that now passes. Check the commits prefixed with `FIX`.
- Covariate construction now builds full-length, zero-padded lag matrices first, then crops valid rows explicitly; this makes positive and negative lag alignment easier to reason about.
- The Gaussian basis now uses lag times directly, so non-zero lag windows get the same basis shape shifted in time rather than a different basis.

@huzafahyde can you have a look at https://github.com/Eelbrain/neuro-currentRF/pull/60/commits/fd15b430afc4a4180c6f4cec983382b7d8069b03? It seemed to me that would be a problem for negative lags?

Note: I noticed some inconsistent white space, will fix that in another PR, for now, turning off white space changes can make review easier:
<img width="417" height="335" alt="image" src="https://github.com/user-attachments/assets/e6959c1b-e4ed-4996-8400-7a9939c95c63" />
